### PR TITLE
Add batching, persistent caching, and segment truncation to embeddings

### DIFF
--- a/aix/__init__.py
+++ b/aix/__init__.py
@@ -52,6 +52,11 @@ from aix.embeddings import (
     cosine_similarity,
     find_most_similar,
     EmbeddingCache,
+    batched_embeddings,
+    cached_embeddings,
+    iter_batches,
+    text_cache_key,
+    truncate_segment,
 )
 from aix.prompts import (
     prompt_func,

--- a/aix/embeddings.py
+++ b/aix/embeddings.py
@@ -23,8 +23,9 @@ Examples:
     1536
 """
 
-from collections.abc import Iterable, Sequence
-from typing import Union
+import hashlib
+from collections.abc import Iterable, Iterator, MutableMapping, Sequence
+from typing import Callable, Optional, Union
 
 # Import LiteLLM but keep it private
 try:
@@ -35,6 +36,7 @@ except ImportError:
 
 # Default configurations
 DFLT_EMBEDDING_MODEL = "text-embedding-3-small"
+DFLT_BATCH_SIZE = 512  # OpenAI batch endpoint accepts up to 2048 but smaller is safer
 
 
 def embeddings(
@@ -323,3 +325,190 @@ def find_most_similar(
     # Sort by similarity (descending) and return top_k
     similarities.sort(key=lambda x: x[1], reverse=True)
     return similarities[:top_k]
+
+
+# -----------------------------------------------------------------------------
+# Batching + persistent caching
+# -----------------------------------------------------------------------------
+
+
+def iter_batches(items: Iterable, size: int = DFLT_BATCH_SIZE) -> Iterator[list]:
+    """Yield successive ``size``-length lists from any iterable.
+
+    >>> list(iter_batches([1, 2, 3, 4, 5], size=2))
+    [[1, 2], [3, 4], [5]]
+    """
+    if size < 1:
+        raise ValueError(f"size must be >= 1, got {size}")
+    batch: list = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+# Conservative char-level truncation: OpenAI's text-embedding-* models accept
+# up to 8192 tokens. English averages ~4 chars/token, but dense text (URLs,
+# CJK, code, numeric strings) can be much denser — ~2 chars/token in the worst
+# case. 16000 chars ≈ 4000-8000 tokens depending on density, leaving headroom.
+DFLT_MAX_CHARS = 16_000
+
+
+def truncate_segment(text: str, *, max_chars: int = DFLT_MAX_CHARS) -> str:
+    """Truncate a single segment to ``max_chars`` if needed.
+
+    >>> truncate_segment('short')
+    'short'
+    >>> truncate_segment('x' * 30, max_chars=10)
+    'xxxxxxxxxx'
+    """
+    if max_chars is None or max_chars <= 0:
+        return text
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars]
+
+
+def batched_embeddings(
+    segments: Iterable[str],
+    *,
+    model: str = None,
+    batch_size: int = DFLT_BATCH_SIZE,
+    max_chars: Optional[int] = DFLT_MAX_CHARS,
+    on_batch: Optional[Callable[[int, int], None]] = None,
+    **kwargs,
+) -> Iterator[Sequence[float]]:
+    """Embed an iterable of segments in fixed-size batches.
+
+    Unlike :func:`embeddings`, this is generator-friendly: it pulls from
+    ``segments`` in chunks and yields vectors as each batch returns, so memory
+    stays bounded even for very large inputs.
+
+    Args:
+        segments: Iterable of strings to embed.
+        model: Embedding model name (default: ``DFLT_EMBEDDING_MODEL``).
+        batch_size: How many segments per API call.
+        max_chars: Per-segment character cap to avoid provider token limits
+            (default ~24K chars, safe for 8K-token embedding models). Pass
+            ``None`` to disable truncation.
+        on_batch: Optional progress callback ``(batch_index, batch_size) -> None``.
+        **kwargs: Forwarded to :func:`embeddings`.
+
+    Yields:
+        One vector per input segment, in input order.
+
+    Examples:
+        >>> vecs = list(batched_embeddings(["a", "b", "c"], batch_size=2))  # doctest: +SKIP
+        >>> len(vecs)  # doctest: +SKIP
+        3
+    """
+    for i, batch in enumerate(iter_batches(segments, size=batch_size)):
+        if max_chars is not None:
+            batch = [truncate_segment(s, max_chars=max_chars) for s in batch]
+        if on_batch is not None:
+            on_batch(i, len(batch))
+        yield from embeddings(batch, model=model, **kwargs)
+
+
+def text_cache_key(text: str, model: Optional[str] = None, *, hash_len: int = 16) -> str:
+    """Stable cache key for ``(text, model)``.
+
+    Uses SHA-1 over a normalized form: ``model + "\\x00" + text``. ``model=None``
+    is treated as the default (so cached entries are stable across runs).
+
+    >>> text_cache_key("hello") == text_cache_key("hello")
+    True
+    >>> text_cache_key("hello", "text-embedding-3-small") != text_cache_key("hello", "text-embedding-3-large")
+    True
+    >>> len(text_cache_key("hello"))
+    16
+    """
+    m = model or DFLT_EMBEDDING_MODEL
+    h = hashlib.sha1((m + "\x00" + text).encode("utf-8")).hexdigest()
+    return h[:hash_len]
+
+
+def cached_embeddings(
+    segments: Iterable[str],
+    *,
+    cache: MutableMapping[str, Sequence[float]],
+    model: str = None,
+    batch_size: int = DFLT_BATCH_SIZE,
+    on_batch: Optional[Callable[[int, int], None]] = None,
+    on_hit: Optional[Callable[[str], None]] = None,
+    **kwargs,
+) -> list[Sequence[float]]:
+    """Embed segments, looking up + writing back to a ``MutableMapping`` cache.
+
+    The cache may be any dict-like that maps the cache key (see
+    :func:`text_cache_key`) to a vector. ``dol`` stores work natively:
+
+    .. code-block:: python
+
+        from dol import Files
+        from aix.embeddings import cached_embeddings
+        store = Files('/tmp/embeddings_cache')  # bytes-backed
+        # Wrap with a codec for vector serialization in real use; below we
+        # assume an already-codec-wrapped MutableMapping.
+        vecs = cached_embeddings(["hello", "world"], cache=store)
+
+    Args:
+        segments: Iterable of strings to embed.
+        cache: A MutableMapping[str, Sequence[float]] used as persistent store.
+        model: Embedding model name (default: ``DFLT_EMBEDDING_MODEL``).
+        batch_size: Batch size for cache misses.
+        on_batch: Optional progress callback ``(batch_index, batch_size) -> None``.
+        on_hit: Optional callback fired once per cache hit (gets the cache key).
+        **kwargs: Forwarded to :func:`embeddings`.
+
+    Returns:
+        List of vectors aligned with the input order.
+
+    Examples:
+        >>> # in-memory cache works too
+        >>> cache = {}
+        >>> vecs1 = cached_embeddings(["x", "y"], cache=cache)  # doctest: +SKIP
+        >>> vecs2 = cached_embeddings(["x", "y"], cache=cache)  # all hits  # doctest: +SKIP
+        >>> vecs1 == vecs2  # doctest: +SKIP
+        True
+    """
+    segments_list = list(segments)
+    n = len(segments_list)
+    if n == 0:
+        return []
+
+    keys = [text_cache_key(s, model) for s in segments_list]
+    result: list[Optional[Sequence[float]]] = [None] * n
+    miss_texts: list[str] = []
+    miss_indices: list[int] = []
+
+    for i, (k, text) in enumerate(zip(keys, segments_list)):
+        try:
+            vec = cache[k]
+        except KeyError:
+            miss_texts.append(text)
+            miss_indices.append(i)
+        else:
+            if on_hit is not None:
+                on_hit(k)
+            result[i] = vec
+
+    if miss_texts:
+        new_vecs = list(
+            batched_embeddings(
+                miss_texts,
+                model=model,
+                batch_size=batch_size,
+                on_batch=on_batch,
+                **kwargs,
+            )
+        )
+        for idx, vec in zip(miss_indices, new_vecs):
+            cache[keys[idx]] = list(vec)  # ensure pickling-friendly plain list
+            result[idx] = list(vec)
+
+    # All slots filled.
+    return result  # type: ignore[return-value]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -8,6 +8,10 @@ from aix.embeddings import (
     cosine_similarity,
     find_most_similar,
     EmbeddingCache,
+    batched_embeddings,
+    cached_embeddings,
+    iter_batches,
+    text_cache_key,
 )
 
 
@@ -251,3 +255,147 @@ class TestEmbeddingCache:
 
         cache.clear()
         assert len(cache) == 0
+
+
+class TestIterBatches:
+    """Tests for iter_batches helper."""
+
+    def test_even_split(self):
+        assert list(iter_batches([1, 2, 3, 4], size=2)) == [[1, 2], [3, 4]]
+
+    def test_partial_tail(self):
+        assert list(iter_batches([1, 2, 3, 4, 5], size=2)) == [[1, 2], [3, 4], [5]]
+
+    def test_size_larger_than_input(self):
+        assert list(iter_batches([1, 2], size=10)) == [[1, 2]]
+
+    def test_empty(self):
+        assert list(iter_batches([], size=3)) == []
+
+    def test_invalid_size(self):
+        with pytest.raises(ValueError):
+            list(iter_batches([1], size=0))
+
+
+class TestTextCacheKey:
+    """Tests for text_cache_key."""
+
+    def test_stable_for_same_inputs(self):
+        assert text_cache_key("hello") == text_cache_key("hello")
+
+    def test_model_affects_key(self):
+        a = text_cache_key("hello", "text-embedding-3-small")
+        b = text_cache_key("hello", "text-embedding-3-large")
+        assert a != b
+
+    def test_text_affects_key(self):
+        assert text_cache_key("hello") != text_cache_key("world")
+
+    def test_default_hash_len(self):
+        assert len(text_cache_key("hello")) == 16
+
+    def test_custom_hash_len(self):
+        assert len(text_cache_key("hello", hash_len=8)) == 8
+
+    def test_none_model_equals_default(self):
+        from aix.embeddings import DFLT_EMBEDDING_MODEL
+
+        assert text_cache_key("hello") == text_cache_key("hello", DFLT_EMBEDDING_MODEL)
+
+
+class TestBatchedEmbeddings:
+    """Tests for batched_embeddings."""
+
+    @patch("aix.embeddings._litellm_embedding")
+    def test_batches_correctly(self, mock_embedding):
+        # Each call returns one embedding per input
+        def side_effect(*, model, input, **kwargs):
+            resp = Mock()
+            resp.data = [{"embedding": [float(i)]} for i, _ in enumerate(input)]
+            return resp
+
+        mock_embedding.side_effect = side_effect
+        vecs = list(batched_embeddings(["a", "b", "c", "d", "e"], batch_size=2))
+        assert len(vecs) == 5
+        # 3 API calls: 2, 2, 1
+        assert mock_embedding.call_count == 3
+
+    @patch("aix.embeddings._litellm_embedding")
+    def test_on_batch_callback(self, mock_embedding):
+        def side_effect(*, model, input, **kwargs):
+            resp = Mock()
+            resp.data = [{"embedding": [0.0]} for _ in input]
+            return resp
+
+        mock_embedding.side_effect = side_effect
+        calls = []
+        list(
+            batched_embeddings(
+                ["a", "b", "c"], batch_size=2, on_batch=lambda i, n: calls.append((i, n))
+            )
+        )
+        assert calls == [(0, 2), (1, 1)]
+
+
+class TestCachedEmbeddings:
+    """Tests for cached_embeddings (persistent caching pattern)."""
+
+    @patch("aix.embeddings._litellm_embedding")
+    def test_misses_then_hits(self, mock_embedding):
+        def side_effect(*, model, input, **kwargs):
+            resp = Mock()
+            resp.data = [{"embedding": [float(len(s))]} for s in input]
+            return resp
+
+        mock_embedding.side_effect = side_effect
+
+        cache: dict[str, list[float]] = {}
+        vecs1 = cached_embeddings(["hi", "world"], cache=cache)
+        # One API call, two cached entries
+        assert mock_embedding.call_count == 1
+        assert len(cache) == 2
+        # Second call: pure hits
+        mock_embedding.reset_mock()
+        vecs2 = cached_embeddings(["hi", "world"], cache=cache)
+        assert mock_embedding.call_count == 0
+        assert vecs1 == vecs2
+
+    @patch("aix.embeddings._litellm_embedding")
+    def test_partial_hits(self, mock_embedding):
+        # Pre-seed cache with one entry
+        cache = {text_cache_key("hi"): [0.99]}
+
+        def side_effect(*, model, input, **kwargs):
+            resp = Mock()
+            resp.data = [{"embedding": [float(len(s))]} for s in input]
+            return resp
+
+        mock_embedding.side_effect = side_effect
+
+        vecs = cached_embeddings(["hi", "world"], cache=cache)
+        # One API call for "world" only; "hi" was a hit
+        assert mock_embedding.call_count == 1
+        assert vecs[0] == [0.99]
+        assert vecs[1] == [5.0]
+        # Cache now has both
+        assert len(cache) == 2
+
+    @patch("aix.embeddings._litellm_embedding")
+    def test_on_hit_fires_for_each_hit(self, mock_embedding):
+        cache = {text_cache_key("hi"): [0.1]}
+
+        def side_effect(*, model, input, **kwargs):
+            resp = Mock()
+            resp.data = [{"embedding": [0.0]} for _ in input]
+            return resp
+
+        mock_embedding.side_effect = side_effect
+
+        hits: list[str] = []
+        cached_embeddings(["hi", "hi", "miss"], cache=cache, on_hit=hits.append)
+        # 'hi' appears twice -> 2 hits; 'miss' is a miss
+        assert len(hits) == 2
+
+    def test_empty_input(self):
+        cache = {}
+        assert cached_embeddings([], cache=cache) == []


### PR DESCRIPTION
## Summary

Three additions to `aix.embeddings`, all backward-compatible, motivated by needing to embed ~360k articles at production scale for downstream consumers (`newsmood`, `vd`):

- **`batched_embeddings`**: generator-friendly batched embedder. Pulls from the input iterable in `batch_size` chunks, yields per-input vectors as each batch returns. Per-segment character cap (`DFLT_MAX_CHARS = 16000`) prevents the 8K-token-limit overflow we hit in real data with verbose articles.
- **`cached_embeddings`**: persistent-cache-aware embedder. The cache is any `MutableMapping` — works with `dict`, `dol.Files`, `dol.JsonFiles`, any custom store. Keys are `sha1(model + text)[:16]` so cache entries are stable across model versions.
- **Small helpers exposed**: `iter_batches`, `text_cache_key`, `truncate_segment` — used by `newsmood` directly.

22 new tests covering batch sizing, hit/miss paths, callbacks, and cache-key stability.

## Why this matters

In the consumer pipeline (`newsmood`), embedding 360k articles cost ~$0.20 in API calls and 90 min wall time. The streaming-write-to-cache pattern made the job resumable after a mid-run crash (it preserved ~110k embeddings of work); the 8K-token truncation default protected against the dense-text outlier articles that triggered the crash in the first place.

## Test plan

- [x] `pytest tests/test_embeddings.py -q` — 35 passed