### PR TITLE
Fix CI: patch shadowed submodules via sys.modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,23 @@
 """Pytest configuration and shared fixtures."""
 
+import sys
 import pytest
 from unittest.mock import Mock, patch
+
+# `aix/__init__.py` exports `chat`/`embeddings` (the function) under the same
+# name as their submodule, so `aix.chat` resolves to the function on some
+# Python builds. Patch the submodule objects directly to stay version-robust.
+import aix.chat  # noqa: F401
+import aix.embeddings  # noqa: F401
+
+_aix_chat = sys.modules["aix.chat"]
+_aix_embeddings = sys.modules["aix.embeddings"]
 
 
 @pytest.fixture
 def mock_litellm_completion():
     """Mock LiteLLM completion function."""
-    with patch("aix.chat._litellm_completion") as mock:
+    with patch.object(_aix_chat, "_litellm_completion") as mock:
         mock_response = Mock()
         mock_response.choices = [Mock()]
         mock_response.choices[0].message = Mock()
@@ -19,7 +29,7 @@ def mock_litellm_completion():
 @pytest.fixture
 def mock_litellm_embedding():
     """Mock LiteLLM embedding function."""
-    with patch("aix.embeddings._litellm_embedding") as mock:
+    with patch.object(_aix_embeddings, "_litellm_embedding") as mock:
         mock_response = Mock()
         mock_response.data = [{"embedding": [0.1, 0.2, 0.3]}]
         mock.return_value = mock_response

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,5 +1,6 @@
 """Tests for aix.chat module."""
 
+import sys
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from aix.chat import (
@@ -10,6 +11,12 @@ from aix.chat import (
     _normalize_prompt,
     _extract_text_from_response,
 )
+
+# `aix.chat` resolves to the exported function (not the submodule) on some
+# Python builds; patch the submodule object directly so tests are robust.
+import aix.chat  # noqa: F401
+
+_aix_chat = sys.modules["aix.chat"]
 
 
 class TestNormalizePrompt:
@@ -40,7 +47,7 @@ class TestNormalizePrompt:
 class TestChat:
     """Tests for chat function."""
 
-    @patch("aix.chat._litellm_completion")
+    @patch.object(_aix_chat, "_litellm_completion")
     def test_simple_chat(self, mock_completion):
         """Test simple chat with string prompt."""
         # Mock response
@@ -57,7 +64,7 @@ class TestChat:
         call_kwargs = mock_completion.call_args[1]
         assert call_kwargs["messages"] == [{"role": "user", "content": "Hello"}]
 
-    @patch("aix.chat._litellm_completion")
+    @patch.object(_aix_chat, "_litellm_completion")
     def test_chat_with_model(self, mock_completion):
         """Test chat with specific model."""
         mock_response = Mock()
@@ -71,7 +78,7 @@ class TestChat:
         call_kwargs = mock_completion.call_args[1]
         assert call_kwargs["model"] == "gpt-4o"
 
-    @patch("aix.chat._litellm_completion")
+    @patch.object(_aix_chat, "_litellm_completion")
     def test_chat_with_temperature(self, mock_completion):
         """Test chat with custom temperature."""
         mock_response = Mock()
@@ -85,7 +92,7 @@ class TestChat:
         call_kwargs = mock_completion.call_args[1]
         assert call_kwargs["temperature"] == 0.5
 
-    @patch("aix.chat._litellm_completion")
+    @patch.object(_aix_chat, "_litellm_completion")
     def test_chat_streaming(self, mock_completion):
         """Test streaming chat."""
         # Mock streaming response
@@ -107,7 +114,7 @@ class TestChat:
         call_kwargs = mock_completion.call_args[1]
         assert call_kwargs["stream"] is True
 
-    @patch("aix.chat._litellm_completion")
+    @patch.object(_aix_chat, "_litellm_completion")
     def test_chat_with_message_history(self, mock_completion):
         """Test chat with message history."""
         mock_response = Mock()
@@ -131,7 +138,7 @@ class TestChat:
 class TestAsk:
     """Tests for ask convenience function."""
 
-    @patch("aix.chat.chat")
+    @patch.object(_aix_chat, "chat")
     def test_ask(self, mock_chat):
         """Test ask function."""
         mock_chat.return_value = "Paris"
@@ -145,20 +152,20 @@ class TestAsk:
 class TestChatSession:
     """Tests for ChatSession class."""
 
-    @patch("aix.chat.chat")
+    @patch.object(_aix_chat, "chat")
     def test_session_initialization(self, mock_chat):
         """Test session initialization."""
         session = ChatSession()
         assert session.history == []
 
-    @patch("aix.chat.chat")
+    @patch.object(_aix_chat, "chat")
     def test_session_with_system_prompt(self, mock_chat):
         """Test session with system prompt."""
         session = ChatSession(system_prompt="You are helpful")
         assert len(session.history) == 1
         assert session.history[0]["role"] == "system"
 
-    @patch("aix.chat.chat")
+    @patch.object(_aix_chat, "chat")
     def test_session_send(self, mock_chat):
         """Test sending message in session."""
         mock_chat.return_value = "I'm doing well"
@@ -171,7 +178,7 @@ class TestChatSession:
         assert session.history[0]["role"] == "user"
         assert session.history[1]["role"] == "assistant"
 
-    @patch("aix.chat.chat")
+    @patch.object(_aix_chat, "chat")
     def test_session_maintains_history(self, mock_chat):
         """Test that session maintains history across multiple sends."""
         mock_chat.side_effect = ["Hello!", "Your name is Alice"]
@@ -189,7 +196,7 @@ class TestChatSession:
         last_call = mock_chat.call_args[0][0]
         assert len(last_call) == 4
 
-    @patch("aix.chat.chat")
+    @patch.object(_aix_chat, "chat")
     def test_session_clear_history(self, mock_chat):
         """Test clearing session history."""
         mock_chat.return_value = "Response"

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,7 +1,15 @@
 """Tests for aix.embeddings module."""
 
+import sys
 import pytest
 from unittest.mock import Mock, patch
+
+# `aix.embeddings` resolves to the exported function (not the submodule) on
+# some Python builds; patch the submodule object directly for robustness.
+import aix.embeddings  # noqa: F401
+
+_aix_embeddings = sys.modules["aix.embeddings"]
+
 from aix.embeddings import (
     embeddings,
     embed,
@@ -18,7 +26,7 @@ from aix.embeddings import (
 class TestEmbeddings:
     """Tests for embeddings function."""
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_basic_embeddings(self, mock_embedding):
         """Test basic embeddings generation."""
         # Mock response
@@ -35,7 +43,7 @@ class TestEmbeddings:
         assert result[0] == [0.1, 0.2, 0.3]
         assert result[1] == [0.4, 0.5, 0.6]
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_embeddings_with_model(self, mock_embedding):
         """Test embeddings with specific model."""
         mock_response = Mock()
@@ -56,7 +64,7 @@ class TestEmbeddings:
 class TestEmbed:
     """Tests for embed function."""
 
-    @patch("aix.embeddings.embeddings")
+    @patch.object(_aix_embeddings, "embeddings")
     def test_embed_single_text(self, mock_embeddings):
         """Test embedding single text."""
         mock_embeddings.return_value = iter([[0.1, 0.2, 0.3]])
@@ -103,8 +111,8 @@ class TestCosineSimilarity:
 class TestFindMostSimilar:
     """Tests for find_most_similar function."""
 
-    @patch("aix.embeddings.embed")
-    @patch("aix.embeddings.embeddings")
+    @patch.object(_aix_embeddings, "embed")
+    @patch.object(_aix_embeddings, "embeddings")
     def test_find_most_similar_with_string_query(self, mock_embeddings, mock_embed):
         """Test finding most similar with string query."""
         # Mock query embedding
@@ -127,7 +135,7 @@ class TestFindMostSimilar:
         assert results[0][1] == 1.0
         assert results[1][0] == "doc3"  # Second most similar
 
-    @patch("aix.embeddings.embeddings")
+    @patch.object(_aix_embeddings, "embeddings")
     def test_find_most_similar_with_vector_query(self, mock_embeddings):
         """Test finding most similar with pre-computed vector."""
         query_vec = [1.0, 0.0]
@@ -145,8 +153,8 @@ class TestFindMostSimilar:
         assert results[0][0] == "doc1"
         assert abs(results[0][1] - 1.0) < 1e-6
 
-    @patch("aix.embeddings.embed")
-    @patch("aix.embeddings.embeddings")
+    @patch.object(_aix_embeddings, "embed")
+    @patch.object(_aix_embeddings, "embeddings")
     def test_find_most_similar_top_k(self, mock_embeddings, mock_embed):
         """Test that top_k limits results."""
         mock_embed.return_value = [1.0, 0.0]
@@ -167,13 +175,13 @@ class TestFindMostSimilar:
 class TestEmbeddingCache:
     """Tests for EmbeddingCache class."""
 
-    @patch("aix.embeddings.embed")
+    @patch.object(_aix_embeddings, "embed")
     def test_cache_initialization(self, mock_embed):
         """Test cache initialization."""
         cache = EmbeddingCache()
         assert len(cache) == 0
 
-    @patch("aix.embeddings.embed")
+    @patch.object(_aix_embeddings, "embed")
     def test_cache_stores_results(self, mock_embed):
         """Test that cache stores results."""
         mock_embed.return_value = [0.1, 0.2, 0.3]
@@ -184,7 +192,7 @@ class TestEmbeddingCache:
         assert len(cache) == 1
         assert result1 == [0.1, 0.2, 0.3]
 
-    @patch("aix.embeddings.embed")
+    @patch.object(_aix_embeddings, "embed")
     def test_cache_reuses_results(self, mock_embed):
         """Test that cache reuses stored results."""
         mock_embed.return_value = [0.1, 0.2, 0.3]
@@ -197,7 +205,7 @@ class TestEmbeddingCache:
         assert mock_embed.call_count == 1
         assert result1 == result2
 
-    @patch("aix.embeddings.embed")
+    @patch.object(_aix_embeddings, "embed")
     def test_cache_force_refresh(self, mock_embed):
         """Test force refresh bypasses cache."""
         mock_embed.side_effect = [[0.1, 0.2], [0.3, 0.4]]
@@ -210,7 +218,7 @@ class TestEmbeddingCache:
         assert mock_embed.call_count == 2
         assert result1 != result2
 
-    @patch("aix.embeddings.embeddings")
+    @patch.object(_aix_embeddings, "embeddings")
     def test_cache_batch(self, mock_embeddings):
         """Test batch caching."""
         mock_embeddings.return_value = iter([[0.1, 0.2], [0.3, 0.4]])
@@ -221,8 +229,8 @@ class TestEmbeddingCache:
         assert len(results) == 2
         assert len(cache) == 2
 
-    @patch("aix.embeddings.embed")
-    @patch("aix.embeddings.embeddings")
+    @patch.object(_aix_embeddings, "embed")
+    @patch.object(_aix_embeddings, "embeddings")
     def test_cache_batch_partial_cache(self, mock_embeddings, mock_embed):
         """Test batch with partial cache hits."""
         # First, populate cache with one item
@@ -244,7 +252,7 @@ class TestEmbeddingCache:
         assert results[0] == [0.1, 0.2]  # From cache
         assert results[1] == [0.3, 0.4]  # New
 
-    @patch("aix.embeddings.embed")
+    @patch.object(_aix_embeddings, "embed")
     def test_cache_clear(self, mock_embed):
         """Test clearing cache."""
         mock_embed.return_value = [0.1, 0.2]
@@ -306,7 +314,7 @@ class TestTextCacheKey:
 class TestBatchedEmbeddings:
     """Tests for batched_embeddings."""
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_batches_correctly(self, mock_embedding):
         # Each call returns one embedding per input
         def side_effect(*, model, input, **kwargs):
@@ -320,7 +328,7 @@ class TestBatchedEmbeddings:
         # 3 API calls: 2, 2, 1
         assert mock_embedding.call_count == 3
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_on_batch_callback(self, mock_embedding):
         def side_effect(*, model, input, **kwargs):
             resp = Mock()
@@ -342,7 +350,7 @@ class TestBatchedEmbeddings:
 class TestCachedEmbeddings:
     """Tests for cached_embeddings (persistent caching pattern)."""
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_misses_then_hits(self, mock_embedding):
         def side_effect(*, model, input, **kwargs):
             resp = Mock()
@@ -362,7 +370,7 @@ class TestCachedEmbeddings:
         assert mock_embedding.call_count == 0
         assert vecs1 == vecs2
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_partial_hits(self, mock_embedding):
         # Pre-seed cache with one entry
         cache = {text_cache_key("hi"): [0.99]}
@@ -382,7 +390,7 @@ class TestCachedEmbeddings:
         # Cache now has both
         assert len(cache) == 2
 
-    @patch("aix.embeddings._litellm_embedding")
+    @patch.object(_aix_embeddings, "_litellm_embedding")
     def test_on_hit_fires_for_each_hit(self, mock_embedding):
         cache = {text_cache_key("hi"): [0.1]}
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Tests for aix.models module."""
 
+import sys
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from aix.models import (
@@ -10,11 +11,17 @@ from aix.models import (
 )
 from aix.ai_models import Model
 
+# `aix.models` resolves to the exported `models` object (not the submodule) on
+# some Python builds; patch the submodule object directly for robustness.
+import aix.models  # noqa: F401
+
+_aix_models = sys.modules["aix.models"]
+
 
 class TestModelStore:
     """Tests for ModelStore class."""
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_initialization(self, mock_get_manager):
         """Test ModelStore initialization."""
         mock_manager = Mock()
@@ -25,7 +32,7 @@ class TestModelStore:
         assert store._manager is mock_manager
         assert store._discovered is False
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_auto_discover(self, mock_get_manager):
         """Test auto_discover on initialization."""
         mock_manager = Mock()
@@ -36,7 +43,7 @@ class TestModelStore:
 
         mock_manager.discover_from_source.assert_called_once()
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_discover(self, mock_get_manager):
         """Test discover method."""
         mock_manager = Mock()
@@ -53,7 +60,7 @@ class TestModelStore:
         assert result == mock_models
         assert store._discovered is True
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_getitem_by_id(self, mock_get_manager):
         """Test getting model by ID."""
         mock_manager = Mock()
@@ -66,7 +73,7 @@ class TestModelStore:
 
         assert result == mock_model
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_getitem_by_dict(self, mock_get_manager):
         """Test getting models by filter dict."""
         mock_manager = Mock()
@@ -80,7 +87,7 @@ class TestModelStore:
         assert result == mock_models
         mock_manager.list_models.assert_called_once_with(provider="openai")
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_iter(self, mock_get_manager):
         """Test iterating over model IDs."""
         mock_manager = Mock()
@@ -93,7 +100,7 @@ class TestModelStore:
         assert "model1" in ids
         assert "model2" in ids
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_len(self, mock_get_manager):
         """Test getting number of models."""
         mock_manager = Mock()
@@ -104,7 +111,7 @@ class TestModelStore:
 
         assert len(store) == 2
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_contains(self, mock_get_manager):
         """Test checking if model exists."""
         mock_manager = Mock()
@@ -116,7 +123,7 @@ class TestModelStore:
         assert "gpt-4" in store
         assert "nonexistent" not in store
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_filter(self, mock_get_manager):
         """Test filtering models."""
         mock_manager = Mock()
@@ -140,7 +147,7 @@ class TestModelStore:
             custom_filter=None,
         )
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_search(self, mock_get_manager):
         """Test searching models."""
         mock_manager = Mock()
@@ -160,7 +167,7 @@ class TestModelStore:
         assert len(results) == 2
         assert all("gpt" in m.id.lower() for m in results)
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_by_provider(self, mock_get_manager):
         """Test getting models by provider."""
         mock_manager = Mock()
@@ -175,7 +182,7 @@ class TestModelStore:
 
         assert result == mock_models
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_by_task(self, mock_get_manager):
         """Test getting models by task."""
         mock_manager = Mock()
@@ -198,7 +205,7 @@ class TestModelStore:
             custom_filter=None,
         )
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_recommend(self, mock_get_manager):
         """Test model recommendations."""
         mock_manager = Mock()
@@ -226,7 +233,7 @@ class TestModelStore:
         assert len(result) == 1
         assert result[0].id == "cheap"
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_get_info(self, mock_get_manager):
         """Test getting model info."""
         mock_manager = Mock()
@@ -239,7 +246,7 @@ class TestModelStore:
 
         assert result == mock_model
 
-    @patch("aix.models.get_manager")
+    @patch.object(_aix_models, "get_manager")
     def test_get_connector_metadata(self, mock_get_manager):
         """Test getting connector metadata."""
         mock_manager = Mock()
@@ -256,7 +263,7 @@ class TestModelStore:
 class TestConvenienceFunctions:
     """Tests for convenience functions."""
 
-    @patch("aix.models.models")
+    @patch.object(_aix_models, "models")
     def test_discover_available_models(self, mock_models):
         """Test discover_available_models function."""
         mock_models.discover.return_value = []
@@ -265,7 +272,7 @@ class TestConvenienceFunctions:
 
         mock_models.discover.assert_called_once_with(source="openrouter", verbose=True)
 
-    @patch("aix.models.models")
+    @patch.object(_aix_models, "models")
     def test_get_model_info(self, mock_models):
         """Test get_model_info function."""
         mock_model = Model(id="gpt-4", provider="openai")
@@ -276,7 +283,7 @@ class TestConvenienceFunctions:
         assert result == mock_model
         mock_models.get_info.assert_called_once_with("gpt-4")
 
-    @patch("aix.models.models")
+    @patch.object(_aix_models, "models")
     def test_find_models(self, mock_models):
         """Test find_models function."""
         mock_results = [Model(id="gpt-4", provider="openai")]


### PR DESCRIPTION
## Problem
The wads/uv CI has **never passed** on aix — 47 tests fail in CI (3.10/3.12) while passing locally on 3.12. Pre-existing, exposed by the CI migration in #20.

## Root cause
`aix/__init__.py` exports `chat`/`embeddings`/`models` under the **same name as their submodule** (`from aix.chat import chat`), so `getattr(aix, 'chat')` returns the *function*, not the *module*. `unittest.mock.patch("aix.chat._litellm_completion")` then resolves to the function on some CPython builds (CI's) and the module on others (local 3.12) — a known mock target-resolution discrepancy. The shadowing is **required** by the public API (`from aix import chat`, `aix.chat(...)`), so the fix belongs in the tests.

## Fix
Patch the submodule objects directly via `sys.modules['aix.chat']` (etc.), which resolves deterministically on **every** Python version. Scoped to the 3 names where an export collides with its submodule: `chat`, `embeddings`, `models` (`audio`/`image`/`prompts` aren't shadowed and already passed).

Files: `conftest.py`, `test_chat.py`, `test_embeddings.py`, `test_models.py`. **139 tests pass.**