### PR TITLE
Central config (SSOT) for per-function model defaults (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,75 @@ models.discover()
 print(list(models)[:5])  # ['openai/gpt-4o', 'openai/gpt-4o-mini', ...]
 ```
 
+## Configuration
+
+`aix` works with zero configuration — every function ships with sensible default
+models. When you want to change *which model a function uses by default* (and
+related parameters like temperature, image size, or TTS voice), there is a single
+source of truth: `aix.config`.
+
+Defaults are resolved in layers, **highest precedence first**:
+
+1. **Explicit call argument** — `chat("hi", model="...")` always wins.
+2. **Runtime override** — `aix.configure(...)` (persistent) or `aix.using(...)` (scoped).
+3. **Environment variables** — `AIX_CHAT_MODEL`, `AIX_CHAT_TEMPERATURE`,
+   `AIX_EMBEDDING_MODEL`, `AIX_IMAGE_MODEL`, `AIX_TTS_MODEL`, `AIX_TTS_VOICE`,
+   `AIX_TRANSCRIPTION_MODEL`, …
+4. **User config file** — a TOML file (see below).
+5. **Shipped defaults** — the built-in values.
+
+```python
+import aix
+
+# Inspect the active configuration
+cfg = aix.get_config()
+cfg.chat.model            # e.g. 'gpt-4o-mini'
+cfg.embeddings.model      # e.g. 'text-embedding-3-small'
+
+# Persistently change a default (everything below an explicit arg still respects it)
+aix.configure(chat_model="anthropic/claude-sonnet-4", chat_temperature=0.2)
+
+# Scoped override that restores on exit
+with aix.using(chat_model="openai/gpt-4o-mini"):
+    aix.chat("quick + cheap question")
+# back to the configured default here
+```
+
+### Config file
+
+Create a TOML file at your platform's app-config dir (or point `AIX_CONFIG_FILE`
+at any path):
+
+```toml
+[chat]
+model = "openai/gpt-4o-mini"
+temperature = 1.0
+
+[embeddings]
+model = "text-embedding-3-small"
+
+[image]
+model = "dall-e-3"
+size = "1024x1024"
+
+[audio]
+tts_model = "tts-1"
+tts_voice = "alloy"
+transcription_model = "whisper-1"
+
+[aliases]              # semantic names (resolution coming soon)
+fast = "openai/gpt-4o-mini"
+best = "anthropic/claude-sonnet-4"
+```
+
+Find the active path with `aix.config.config_file_path()`. Environment variables
+override file values; explicit call arguments override everything.
+
+> **Note on credentials:** API keys are currently discovered by the provider
+> backend (LiteLLM) from standard environment variables such as `OPENAI_API_KEY`,
+> `ANTHROPIC_API_KEY`, and `OPENROUTER_API_KEY`. A unified, discoverable key
+> resolver with actionable error messages is in progress.
+
 ## Core Features
 
 ### 1. Chat Interface

--- a/aix/__init__.py
+++ b/aix/__init__.py
@@ -44,6 +44,17 @@ Backends:
 For detailed documentation, see: https://github.com/thorwhalen/aix
 """
 
+# Configuration (single source of truth for per-function defaults)
+from aix import config
+from aix.config import (
+    AixConfig,
+    get_config,
+    set_config,
+    configure,
+    using,
+    load_config,
+)
+
 # Core interfaces (new clean API)
 from aix.chat import chat, ask, chat_with_history, ChatSession
 from aix.embeddings import (
@@ -110,6 +121,14 @@ __version__ = "0.1.0"
 
 # Public API
 __all__ = [
+    # Configuration
+    "config",
+    "AixConfig",
+    "get_config",
+    "set_config",
+    "configure",
+    "using",
+    "load_config",
     # Core chat
     "chat",
     "ask",

--- a/aix/audio.py
+++ b/aix/audio.py
@@ -29,11 +29,14 @@ except ImportError:
     _litellm_speech = None
 
 
-# Default configurations
-DFLT_TTS_MODEL = "tts-1"
-DFLT_TTS_VOICE = "alloy"  # Options: alloy, echo, fable, onyx, nova, shimmer
-DFLT_TTS_SPEED = 1.0
-DFLT_TRANSCRIPTION_MODEL = "whisper-1"
+# Shipped-default constants, kept for backward compatibility. The *active*
+# defaults are resolved from ``aix.config`` at call time (see aix/config.py).
+from aix.config import get_config as _get_config, AudioConfig as _AudioConfig
+
+DFLT_TTS_MODEL = _AudioConfig().tts_model
+DFLT_TTS_VOICE = _AudioConfig().tts_voice  # alloy, echo, fable, onyx, nova, shimmer
+DFLT_TTS_SPEED = _AudioConfig().tts_speed
+DFLT_TRANSCRIPTION_MODEL = _AudioConfig().transcription_model
 
 
 class GeneratedAudio:
@@ -231,10 +234,11 @@ def text_to_speech(
             "Install it with: pip install litellm"
         )
 
-    # Apply defaults
-    model = model or DFLT_TTS_MODEL
-    voice = voice or DFLT_TTS_VOICE
-    speed = speed if speed is not None else DFLT_TTS_SPEED
+    # Apply defaults from the active config (explicit args still win)
+    _audio_cfg = _get_config().audio
+    model = model or _audio_cfg.tts_model
+    voice = voice or _audio_cfg.tts_voice
+    speed = speed if speed is not None else _audio_cfg.tts_speed
 
     # Build parameters
     params = {
@@ -335,7 +339,7 @@ def transcribe(
         filename = getattr(audio, "name", "audio.mp3")
 
     # Apply defaults
-    model = model or DFLT_TRANSCRIPTION_MODEL
+    model = model or _get_config().audio.transcription_model
 
     # Build parameters
     params = {
@@ -468,7 +472,7 @@ def translate_audio(
         audio_data = audio.read()
         filename = getattr(audio, "name", "audio.mp3")
 
-    model = model or DFLT_TRANSCRIPTION_MODEL
+    model = model or _get_config().audio.transcription_model
 
     # Use translation endpoint
     params = {

--- a/aix/chat.py
+++ b/aix/chat.py
@@ -32,6 +32,8 @@ Examples:
 from collections.abc import Iterable
 from typing import Union, Any
 
+from aix.config import get_config as _get_config, ChatConfig as _ChatConfig
+
 # Import LiteLLM but keep it private - users shouldn't call it directly
 try:
     from litellm import completion as _litellm_completion
@@ -41,10 +43,12 @@ except ImportError:
     _ModelResponse = None
 
 
-# Default configurations
-DFLT_CHAT_MODEL = "gpt-4o-mini"
-DFLT_TEMPERATURE = 1.0
-DFLT_MAX_TOKENS = None
+# Shipped-default constants, kept for backward compatibility. The *active*
+# defaults are resolved from ``aix.config`` at call time (see aix/config.py),
+# so changing config -- not these constants -- is what affects behavior.
+DFLT_CHAT_MODEL = _ChatConfig().model
+DFLT_TEMPERATURE = _ChatConfig().temperature
+DFLT_MAX_TOKENS = _ChatConfig().max_tokens
 
 
 def _normalize_prompt(
@@ -182,9 +186,12 @@ def chat(
     # Normalize inputs
     messages = _normalize_prompt(prompt)
 
-    # Apply defaults
-    model = model or DFLT_CHAT_MODEL
-    temperature = temperature if temperature is not None else DFLT_TEMPERATURE
+    # Apply defaults from the active config (explicit args still win)
+    cfg = _get_config().chat
+    model = model or cfg.model
+    temperature = temperature if temperature is not None else cfg.temperature
+    if max_tokens is None:
+        max_tokens = cfg.max_tokens
 
     # Build LiteLLM parameters
     litellm_kwargs = {

--- a/aix/config.py
+++ b/aix/config.py
@@ -1,0 +1,332 @@
+"""Central configuration for AIX (single source of truth for defaults).
+
+This module is the SSOT for *what model (and related parameters) each AIX
+function uses by default*. Instead of scattering hardcoded ``DFLT_*`` constants
+across modules, every function resolves its defaults from a single, layered
+configuration.
+
+Resolution layers, highest precedence first:
+
+1. **Explicit call argument** -- e.g. ``chat(..., model=...)`` always wins
+   (handled at the call site, not here).
+2. **Runtime override** -- :func:`configure` swaps the active config; :func:`using`
+   scopes an override to a ``with`` block.
+3. **Environment variables** -- ``AIX_CHAT_MODEL``, ``AIX_CHAT_TEMPERATURE``,
+   ``AIX_EMBEDDING_MODEL``, ``AIX_IMAGE_MODEL``, ``AIX_TTS_MODEL``,
+   ``AIX_TTS_VOICE``, ``AIX_TRANSCRIPTION_MODEL``, ...
+4. **User config file** -- a TOML file at ``<app config dir>/config.toml``
+   (override the path with the ``AIX_CONFIG_FILE`` environment variable).
+5. **Shipped defaults** -- the dataclass field defaults below.
+
+The schema is a set of frozen dataclasses (immutable). A module-level *active
+config* pointer holds the currently resolved :class:`AixConfig`; :func:`configure`
+and :func:`using` swap that pointer rather than mutating in place.
+
+Examples:
+    >>> from aix import config
+    >>> c = config.get_config()
+    >>> isinstance(c.chat.model, str)
+    True
+
+    Scoped override (does not leak outside the block):
+
+    >>> with config.using(chat_model="some/model"):
+    ...     config.get_config().chat.model
+    'some/model'
+    >>> config.get_config().chat.model == c.chat.model
+    True
+
+    TOML config file shape::
+
+        [chat]
+        model = "openai/gpt-4o-mini"
+        temperature = 1.0
+
+        [embeddings]
+        model = "text-embedding-3-small"
+
+        [image]
+        model = "dall-e-3"
+        size = "1024x1024"
+
+        [audio]
+        tts_model = "tts-1"
+        tts_voice = "alloy"
+        transcription_model = "whisper-1"
+
+        [aliases]
+        fast = "openai/gpt-4o-mini"
+        best = "anthropic/claude-sonnet-4"
+"""
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field, fields, replace, is_dataclass, MISSING
+from typing import Any, Callable, Optional, Mapping, Iterator
+
+try:  # Python 3.11+
+    import tomllib as _tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+    try:
+        import tomli as _tomllib  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover
+        _tomllib = None
+
+
+__all__ = [
+    "ChatConfig",
+    "EmbeddingConfig",
+    "ImageConfig",
+    "AudioConfig",
+    "VideoConfig",
+    "AixConfig",
+    "load_config",
+    "get_config",
+    "set_config",
+    "configure",
+    "using",
+    "config_file_path",
+]
+
+
+def _opt(default: Any, *, flat: str, cast: Callable[[str], Any] = str):
+    """Define a config field.
+
+    Args:
+        default: The shipped default value.
+        flat: The flat override name (used both for ``configure(**)`` kwargs and,
+            uppercased and ``AIX_``-prefixed, for the environment variable).
+            e.g. ``flat="chat_model"`` -> env var ``AIX_CHAT_MODEL``.
+        cast: Callable used to coerce a string (from env var) to the field type.
+    """
+    return field(default=default, metadata={"flat": flat, "cast": cast})
+
+
+def _env_name(f) -> str:
+    """Environment-variable name for a config field (``AIX_`` + flat, uppercased)."""
+    return "AIX_" + f.metadata["flat"].upper()
+
+
+@dataclass(frozen=True)
+class ChatConfig:
+    """Defaults for ``chat`` / ``ask`` / ``prompt_func``."""
+
+    model: str = _opt("gpt-4o-mini", flat="chat_model")
+    temperature: float = _opt(1.0, flat="chat_temperature", cast=float)
+    max_tokens: Optional[int] = _opt(None, flat="chat_max_tokens", cast=int)
+
+
+@dataclass(frozen=True)
+class EmbeddingConfig:
+    """Defaults for ``embeddings`` / ``embed``."""
+
+    model: str = _opt("text-embedding-3-small", flat="embedding_model")
+    batch_size: int = _opt(512, flat="embedding_batch_size", cast=int)
+
+
+@dataclass(frozen=True)
+class ImageConfig:
+    """Defaults for ``generate_image`` / ``generate_images``."""
+
+    model: str = _opt("dall-e-2", flat="image_model")
+    size: str = _opt("1024x1024", flat="image_size")
+    quality: str = _opt("standard", flat="image_quality")
+    num_images: int = _opt(1, flat="image_num_images", cast=int)
+
+
+@dataclass(frozen=True)
+class AudioConfig:
+    """Defaults for ``text_to_speech`` / ``transcribe`` / ``translate_audio``."""
+
+    tts_model: str = _opt("tts-1", flat="tts_model")
+    tts_voice: str = _opt("alloy", flat="tts_voice")
+    tts_speed: float = _opt(1.0, flat="tts_speed", cast=float)
+    transcription_model: str = _opt("whisper-1", flat="transcription_model")
+
+
+@dataclass(frozen=True)
+class VideoConfig:
+    """Defaults for ``generate_video`` (provider-dependent)."""
+
+    provider: Optional[str] = _opt(None, flat="video_provider")
+
+
+# Maps the AixConfig attribute name -> (sub-config class, TOML section name).
+# The attribute name doubles as the TOML section name.
+_SECTIONS = {
+    "chat": ChatConfig,
+    "embeddings": EmbeddingConfig,
+    "image": ImageConfig,
+    "audio": AudioConfig,
+    "video": VideoConfig,
+}
+
+
+@dataclass(frozen=True)
+class AixConfig:
+    """Top-level AIX configuration (single source of truth for defaults)."""
+
+    chat: ChatConfig = field(default_factory=ChatConfig)
+    embeddings: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    image: ImageConfig = field(default_factory=ImageConfig)
+    audio: AudioConfig = field(default_factory=AudioConfig)
+    video: VideoConfig = field(default_factory=VideoConfig)
+    aliases: Mapping[str, str] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------- #
+# Loading (file + env layers)
+# --------------------------------------------------------------------------- #
+
+
+def config_file_path() -> str:
+    """Path to the user config file (env ``AIX_CONFIG_FILE`` overrides default)."""
+    explicit = os.environ.get("AIX_CONFIG_FILE")
+    if explicit:
+        return explicit
+    # Imported lazily to avoid importing the data-dir machinery unless needed.
+    from aix.util import djoin
+
+    return djoin("config.toml")
+
+
+def _read_toml(path: Optional[str]) -> dict:
+    """Read a TOML config file, returning ``{}`` if missing or unreadable."""
+    path = path or config_file_path()
+    if not path or not os.path.isfile(path) or _tomllib is None:
+        return {}
+    with open(path, "rb") as f:
+        return _tomllib.load(f)
+
+
+def _build_subconfig(cls, section: dict, environ: Mapping[str, str]):
+    """Build one sub-config: shipped defaults < TOML section < env vars."""
+    kwargs = {}
+    for f in fields(cls):
+        toml_key = f.name
+        if toml_key in section:
+            kwargs[f.name] = section[toml_key]
+        env = _env_name(f)
+        if env in environ:
+            kwargs[f.name] = f.metadata["cast"](environ[env])
+    return cls(**kwargs)
+
+
+def load_config(
+    path: Optional[str] = None, *, environ: Optional[Mapping[str, str]] = None
+) -> AixConfig:
+    """Resolve an :class:`AixConfig` from shipped defaults, TOML file, and env.
+
+    Precedence (low to high): shipped defaults < TOML file < environment variables.
+    Runtime overrides (:func:`configure`/:func:`using`) and explicit call arguments
+    sit above this and are applied elsewhere.
+
+    Args:
+        path: Optional explicit TOML path. Defaults to :func:`config_file_path`.
+        environ: Optional environment mapping (defaults to ``os.environ``).
+
+    Returns:
+        A fully resolved :class:`AixConfig`.
+    """
+    environ = os.environ if environ is None else environ
+    toml_data = _read_toml(path)
+
+    sub = {
+        attr: _build_subconfig(cls, toml_data.get(attr, {}) or {}, environ)
+        for attr, cls in _SECTIONS.items()
+    }
+    aliases = dict(toml_data.get("aliases", {}) or {})
+    return AixConfig(aliases=aliases, **sub)
+
+
+# --------------------------------------------------------------------------- #
+# Active config + runtime overrides
+# --------------------------------------------------------------------------- #
+
+_active_config: AixConfig = load_config()
+
+# Flat override name -> (section attr, field name), built from field metadata.
+_FLAT_INDEX = {
+    f.metadata["flat"]: (attr, f.name)
+    for attr, cls in _SECTIONS.items()
+    for f in fields(cls)
+}
+
+
+def get_config() -> AixConfig:
+    """Return the current active :class:`AixConfig`."""
+    return _active_config
+
+
+def set_config(config: AixConfig) -> AixConfig:
+    """Replace the active config wholesale. Returns the new active config."""
+    global _active_config
+    if not isinstance(config, AixConfig):
+        raise TypeError(f"Expected AixConfig, got {type(config)}")
+    _active_config = config
+    return _active_config
+
+
+def _apply_overrides(base: AixConfig, overrides: Mapping[str, Any]) -> AixConfig:
+    """Return a new AixConfig with flat ``overrides`` applied to ``base``.
+
+    Keys are the flat names (e.g. ``chat_model``, ``tts_voice``) or top-level
+    section names mapped to dicts (e.g. ``chat={'model': ...}``) or ``aliases``.
+    """
+    section_updates: dict[str, dict] = {}
+    new_aliases = None
+    for key, value in overrides.items():
+        if key == "aliases":
+            new_aliases = dict(value)
+        elif key in _SECTIONS and isinstance(value, Mapping):
+            section_updates.setdefault(key, {}).update(value)
+        elif key in _FLAT_INDEX:
+            attr, fname = _FLAT_INDEX[key]
+            section_updates.setdefault(attr, {})[fname] = value
+        else:
+            raise TypeError(
+                f"Unknown config override {key!r}. Valid flat keys: "
+                f"{sorted(_FLAT_INDEX)}; or a section name in "
+                f"{sorted(_SECTIONS)}; or 'aliases'."
+            )
+
+    changes: dict[str, Any] = {}
+    for attr, updates in section_updates.items():
+        changes[attr] = replace(getattr(base, attr), **updates)
+    if new_aliases is not None:
+        changes["aliases"] = new_aliases
+    return replace(base, **changes)
+
+
+def configure(**overrides: Any) -> AixConfig:
+    """Apply runtime overrides to the active config and return it.
+
+    Examples:
+        >>> from aix import config
+        >>> _ = config.configure(chat_model="openai/gpt-4o-mini")
+        >>> config.get_config().chat.model
+        'openai/gpt-4o-mini'
+        >>> _ = config.configure(chat={"temperature": 0.2})
+        >>> config.get_config().chat.temperature
+        0.2
+    """
+    return set_config(_apply_overrides(_active_config, overrides))
+
+
+@contextmanager
+def using(**overrides: Any) -> Iterator[AixConfig]:
+    """Context manager applying scoped overrides, restored on exit.
+
+    Examples:
+        >>> from aix import config
+        >>> with config.using(chat_temperature=0.0) as c:
+        ...     c.chat.temperature
+        0.0
+    """
+    global _active_config
+    previous = _active_config
+    try:
+        _active_config = _apply_overrides(previous, overrides)
+        yield _active_config
+    finally:
+        _active_config = previous

--- a/aix/embeddings.py
+++ b/aix/embeddings.py
@@ -27,6 +27,8 @@ import hashlib
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from typing import Callable, Optional, Union
 
+from aix.config import get_config as _get_config, EmbeddingConfig as _EmbeddingConfig
+
 # Import LiteLLM but keep it private
 try:
     from litellm import embedding as _litellm_embedding
@@ -34,9 +36,10 @@ except ImportError:
     _litellm_embedding = None
 
 
-# Default configurations
-DFLT_EMBEDDING_MODEL = "text-embedding-3-small"
-DFLT_BATCH_SIZE = 512  # OpenAI batch endpoint accepts up to 2048 but smaller is safer
+# Shipped-default constants, kept for backward compatibility. The *active*
+# defaults are resolved from ``aix.config`` at call time (see aix/config.py).
+DFLT_EMBEDDING_MODEL = _EmbeddingConfig().model
+DFLT_BATCH_SIZE = _EmbeddingConfig().batch_size
 
 
 def embeddings(
@@ -94,8 +97,8 @@ def embeddings(
     if not segments_list:
         raise ValueError("Cannot generate embeddings for empty sequence")
 
-    # Apply defaults
-    model = model or DFLT_EMBEDDING_MODEL
+    # Apply defaults from the active config (explicit args still win)
+    model = model or _get_config().embeddings.model
 
     # Build LiteLLM parameters
     litellm_kwargs = {
@@ -428,7 +431,7 @@ def text_cache_key(
     >>> len(text_cache_key("hello"))
     16
     """
-    m = model or DFLT_EMBEDDING_MODEL
+    m = model or _get_config().embeddings.model
     h = hashlib.sha1((m + "\x00" + text).encode("utf-8")).hexdigest()
     return h[:hash_len]
 

--- a/aix/image.py
+++ b/aix/image.py
@@ -46,11 +46,14 @@ except ImportError:
     PILImage = None
 
 
-# Default configurations
-DFLT_IMAGE_MODEL = "dall-e-2"
-DFLT_IMAGE_SIZE = "1024x1024"
-DFLT_IMAGE_QUALITY = "standard"
-DFLT_NUM_IMAGES = 1
+# Shipped-default constants, kept for backward compatibility. The *active*
+# defaults are resolved from ``aix.config`` at call time (see aix/config.py).
+from aix.config import get_config as _get_config, ImageConfig as _ImageConfig
+
+DFLT_IMAGE_MODEL = _ImageConfig().model
+DFLT_IMAGE_SIZE = _ImageConfig().size
+DFLT_IMAGE_QUALITY = _ImageConfig().quality
+DFLT_NUM_IMAGES = _ImageConfig().num_images
 
 
 class GeneratedImage:
@@ -223,9 +226,10 @@ def generate_image(
             "Install it with: pip install litellm"
         )
 
-    # Apply defaults
-    model = model or DFLT_IMAGE_MODEL
-    size = size or DFLT_IMAGE_SIZE
+    # Apply defaults from the active config (explicit args still win)
+    _img_cfg = _get_config().image
+    model = model or _img_cfg.model
+    size = size or _img_cfg.size
 
     # Build parameters
     params = {
@@ -301,10 +305,11 @@ def generate_images(
             "Install it with: pip install litellm"
         )
 
-    # Apply defaults
-    model = model or DFLT_IMAGE_MODEL
-    size = size or DFLT_IMAGE_SIZE
-    n = n or DFLT_NUM_IMAGES
+    # Apply defaults from the active config (explicit args still win)
+    _img_cfg = _get_config().image
+    model = model or _img_cfg.model
+    size = size or _img_cfg.size
+    n = n or _img_cfg.num_images
 
     # Build parameters
     params = {

--- a/aix/prompts.py
+++ b/aix/prompts.py
@@ -37,6 +37,7 @@ from inspect import signature, Parameter
 
 # Import from aix.chat
 from aix.chat import chat, DFLT_CHAT_MODEL
+from aix.config import get_config as _get_config
 
 
 def _extract_template_vars(template: str) -> list[str]:
@@ -680,7 +681,7 @@ def constrained_answer(
     # Use LiteLLM's response_format for JSON mode
     # This works across OpenAI, Anthropic (via tools), and other providers
     chat_kwargs = {
-        "model": model or DFLT_CHAT_MODEL,
+        "model": model or _get_config().chat.model,
         "response_format": {"type": "json_object"},
     }
     if temperature is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ authors = [{ name = "Thor Whalen" }]
 dependencies = [
     "litellm>=1.0.0",
     "config2py",
+    # TOML parsing for the user config file (aix.config). `tomllib` is stdlib on
+    # 3.11+; `tomli` is the tiny backport for 3.10.
+    "tomli; python_version < '3.11'",
 ]
 
 [project.license]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,133 @@
+"""Tests for the central configuration module (aix.config)."""
+
+import tempfile
+
+import pytest
+
+from aix import config
+from aix.config import (
+    AixConfig,
+    ChatConfig,
+    load_config,
+    get_config,
+    set_config,
+    configure,
+    using,
+)
+
+
+def test_shipped_defaults():
+    """A freshly built config exposes the shipped defaults."""
+    c = AixConfig()
+    assert c.chat.model == ChatConfig().model
+    assert c.chat.temperature == 1.0
+    assert c.embeddings.model == "text-embedding-3-small"
+    assert c.image.model == "dall-e-2"
+    assert c.audio.tts_model == "tts-1"
+    assert c.audio.transcription_model == "whisper-1"
+    assert c.aliases == {}
+
+
+def test_env_layer_overrides_defaults():
+    """Environment variables override shipped defaults, with casting."""
+    environ = {"AIX_CHAT_MODEL": "env/model", "AIX_CHAT_TEMPERATURE": "0.25"}
+    c = load_config(path="/does/not/exist.toml", environ=environ)
+    assert c.chat.model == "env/model"
+    assert c.chat.temperature == 0.25  # cast to float
+    # untouched fields keep their defaults
+    assert c.embeddings.model == "text-embedding-3-small"
+
+
+def test_toml_layer_and_env_precedence():
+    """TOML file fills values; env vars beat the TOML file."""
+    toml = (
+        b'[chat]\nmodel = "toml/model"\ntemperature = 0.9\n'
+        b'[image]\nmodel = "toml/image"\n'
+        b'[aliases]\nbest = "x/y"\n'
+    )
+    with tempfile.NamedTemporaryFile("wb", suffix=".toml", delete=False) as f:
+        f.write(toml)
+        path = f.name
+
+    # env beats toml for chat.model; toml still provides image.model + aliases
+    c = load_config(path=path, environ={"AIX_CHAT_MODEL": "env/model"})
+    assert c.chat.model == "env/model"
+    assert c.chat.temperature == 0.9  # from toml (no env override)
+    assert c.image.model == "toml/image"
+    assert c.aliases == {"best": "x/y"}
+
+
+def test_missing_toml_is_ignored():
+    c = load_config(path="/no/such/file.toml", environ={})
+    assert isinstance(c, AixConfig)
+    assert c.chat.model == ChatConfig().model
+
+
+@pytest.fixture
+def restore_active_config():
+    """Restore the active config after a test mutates it."""
+    saved = get_config()
+    yield
+    set_config(saved)
+
+
+def test_configure_flat_and_nested(restore_active_config):
+    configure(chat_model="a/b")
+    assert get_config().chat.model == "a/b"
+
+    configure(chat={"temperature": 0.2})
+    assert get_config().chat.temperature == 0.2
+    # flat override above is preserved (immutable replace, not reset)
+    assert get_config().chat.model == "a/b"
+
+
+def test_configure_aliases(restore_active_config):
+    configure(aliases={"fast": "a/b"})
+    assert get_config().aliases["fast"] == "a/b"
+
+
+def test_configure_rejects_unknown_key(restore_active_config):
+    with pytest.raises(TypeError):
+        configure(not_a_real_key=1)
+
+
+def test_using_is_scoped(restore_active_config):
+    before = get_config().chat.temperature
+    with using(chat_temperature=0.0) as scoped:
+        assert scoped.chat.temperature == 0.0
+        assert get_config().chat.temperature == 0.0
+    # restored on exit
+    assert get_config().chat.temperature == before
+
+
+def test_using_restores_on_exception(restore_active_config):
+    before = get_config().chat.model
+    with pytest.raises(ValueError):
+        with using(chat_model="temp/model"):
+            assert get_config().chat.model == "temp/model"
+            raise ValueError("boom")
+    assert get_config().chat.model == before
+
+
+def test_config_is_immutable():
+    c = AixConfig()
+    with pytest.raises(Exception):
+        c.chat.model = "nope"  # frozen dataclass
+
+
+def test_set_config_type_checked(restore_active_config):
+    with pytest.raises(TypeError):
+        set_config({"chat": {"model": "x"}})  # not an AixConfig
+
+
+def test_active_config_drives_function_defaults(restore_active_config):
+    """chat()/embeddings() read the active config for their model default."""
+    import sys
+
+    configure(chat_model="active/chat", embedding_model="active/embed")
+    # The DFLT_* constants stay pinned to shipped defaults...
+    chat_mod = sys.modules["aix.chat"]
+    assert chat_mod.DFLT_CHAT_MODEL == ChatConfig().model
+    # ...while the active config reflects the override used at call time.
+    assert get_config().chat.model == "active/chat"
+    assert get_config().embeddings.model == "active/embed"


### PR DESCRIPTION
## Summary

Implements **#23** — a central, single-source-of-truth configuration for *which model (and related parameters) each AIX function uses by default*. Replaces the scattered, hardcoded `DFLT_*` constants with a layered resolver.

This is the foundation the rest of the config/credentials redesign (#22) builds on: #25 (defaults + aliases) and #24 (unified credentials) plug into it.

## What's in it

- **`aix/config.py`** — frozen-dataclass schema (`ChatConfig`, `EmbeddingConfig`, `ImageConfig`, `AudioConfig`, `VideoConfig`, `AixConfig`) plus a layered resolver:
  `explicit call arg > runtime override > AIX_* env vars > TOML file > shipped defaults`.
- Immutable **active-config singleton**, swapped by `configure()` (persistent) and `using()` (scoped context manager) rather than mutated in place.
- Routed `chat`, `embeddings`, `image`, `audio`, and `prompts` default-model selection through the active config. `DFLT_*` names are **kept as backward-compatible shipped-default references**.
- Public API on `aix`: `config`, `get_config`, `set_config`, `configure`, `using`, `load_config`, `AixConfig`.
- `tomli` conditional dependency for TOML parsing on Python < 3.11 (`tomllib` is stdlib on 3.11+).
- README **Configuration** section documenting precedence, the `AIX_*` env vars, and the TOML file shape.

## Resolution layers (highest precedence first)

1. Explicit call argument — `chat("hi", model="...")`
2. Runtime override — `aix.configure(...)` / `with aix.using(...)`
3. Environment variables — `AIX_CHAT_MODEL`, `AIX_CHAT_TEMPERATURE`, `AIX_EMBEDDING_MODEL`, `AIX_IMAGE_MODEL`, `AIX_TTS_MODEL`, `AIX_TTS_VOICE`, `AIX_TRANSCRIPTION_MODEL`, …
4. User config file — TOML at the app-config dir (or `AIX_CONFIG_FILE`)
5. Shipped defaults — dataclass field defaults

## Testing

- New `tests/test_config.py` (12 cases): shipped defaults, env layer + casting, TOML layer + env-beats-TOML precedence, missing-file tolerance, flat & nested `configure()`, alias plumbing, unknown-key rejection, scoped `using()` + restore-on-exception, immutability, type-checked `set_config`.
- Full suite: **151 passed** (139 pre-existing + 12 new). Doctests in `config.py` pass.

## Notes / deferred

- Default model *values* are unchanged here (still `dall-e-2`/`tts-1`/`whisper-1`) — refreshing them + alias **resolution** is #25.
- Credential resolution still relies on LiteLLM's implicit env-var reading — unified resolver is #24.

Refs #23
