### PR TITLE
Refresh default models + semantic alias resolution (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ import aix
 
 # Inspect the active configuration
 cfg = aix.get_config()
-cfg.chat.model            # e.g. 'gpt-4o-mini'
-cfg.embeddings.model      # e.g. 'text-embedding-3-small'
+cfg.chat.model            # 'gpt-4.1-mini'
+cfg.embeddings.model      # 'text-embedding-3-small'
 
 # Persistently change a default (everything below an explicit arg still respects it)
 aix.configure(chat_model="anthropic/claude-sonnet-4", chat_temperature=0.2)
@@ -94,6 +94,24 @@ with aix.using(chat_model="openai/gpt-4o-mini"):
 # back to the configured default here
 ```
 
+### Semantic aliases
+
+Pass an intent-level name instead of a concrete model id. Shipped aliases:
+`fast` (cheap/low-latency), `best` (highest quality), `cheap` (cheapest).
+
+```python
+aix.chat("hard question", model="best")     # -> resolves via the alias table
+aix.chat("quick question", model="fast")
+
+# Add or override aliases (merges with the shipped set)
+aix.configure(aliases={"smart": "anthropic/claude-sonnet-4"})
+aix.resolve_model("smart")                  # 'anthropic/claude-sonnet-4'
+```
+
+Aliases share a namespace with literal model ids: a name that is not a registered
+alias (e.g. `"gpt-4o"`) is passed through unchanged. Inspect available aliases via
+`aix.get_config().aliases`.
+
 ### Config file
 
 Create a TOML file at your platform's app-config dir (or point `AIX_CONFIG_FILE`
@@ -101,7 +119,7 @@ at any path):
 
 ```toml
 [chat]
-model = "openai/gpt-4o-mini"
+model = "gpt-4.1-mini"
 temperature = 1.0
 
 [embeddings]
@@ -112,12 +130,12 @@ model = "dall-e-3"
 size = "1024x1024"
 
 [audio]
-tts_model = "tts-1"
+tts_model = "gpt-4o-mini-tts"
 tts_voice = "alloy"
 transcription_model = "whisper-1"
 
-[aliases]              # semantic names (resolution coming soon)
-fast = "openai/gpt-4o-mini"
+[aliases]              # semantic names -> concrete ids (override the shipped set)
+fast = "gpt-4.1-mini"
 best = "anthropic/claude-sonnet-4"
 ```
 

--- a/aix/__init__.py
+++ b/aix/__init__.py
@@ -53,6 +53,7 @@ from aix.config import (
     configure,
     using,
     load_config,
+    resolve_model,
 )
 
 # Core interfaces (new clean API)
@@ -129,6 +130,7 @@ __all__ = [
     "configure",
     "using",
     "load_config",
+    "resolve_model",
     # Core chat
     "chat",
     "ask",

--- a/aix/audio.py
+++ b/aix/audio.py
@@ -31,7 +31,11 @@ except ImportError:
 
 # Shipped-default constants, kept for backward compatibility. The *active*
 # defaults are resolved from ``aix.config`` at call time (see aix/config.py).
-from aix.config import get_config as _get_config, AudioConfig as _AudioConfig
+from aix.config import (
+    get_config as _get_config,
+    resolve_model as _resolve_model,
+    AudioConfig as _AudioConfig,
+)
 
 DFLT_TTS_MODEL = _AudioConfig().tts_model
 DFLT_TTS_VOICE = _AudioConfig().tts_voice  # alloy, echo, fable, onyx, nova, shimmer
@@ -236,7 +240,7 @@ def text_to_speech(
 
     # Apply defaults from the active config (explicit args still win)
     _audio_cfg = _get_config().audio
-    model = model or _audio_cfg.tts_model
+    model = _resolve_model(model or _audio_cfg.tts_model)
     voice = voice or _audio_cfg.tts_voice
     speed = speed if speed is not None else _audio_cfg.tts_speed
 
@@ -339,7 +343,7 @@ def transcribe(
         filename = getattr(audio, "name", "audio.mp3")
 
     # Apply defaults
-    model = model or _get_config().audio.transcription_model
+    model = _resolve_model(model or _get_config().audio.transcription_model)
 
     # Build parameters
     params = {
@@ -472,7 +476,7 @@ def translate_audio(
         audio_data = audio.read()
         filename = getattr(audio, "name", "audio.mp3")
 
-    model = model or _get_config().audio.transcription_model
+    model = _resolve_model(model or _get_config().audio.transcription_model)
 
     # Use translation endpoint
     params = {

--- a/aix/chat.py
+++ b/aix/chat.py
@@ -32,7 +32,11 @@ Examples:
 from collections.abc import Iterable
 from typing import Union, Any
 
-from aix.config import get_config as _get_config, ChatConfig as _ChatConfig
+from aix.config import (
+    get_config as _get_config,
+    resolve_model as _resolve_model,
+    ChatConfig as _ChatConfig,
+)
 
 # Import LiteLLM but keep it private - users shouldn't call it directly
 try:
@@ -188,7 +192,7 @@ def chat(
 
     # Apply defaults from the active config (explicit args still win)
     cfg = _get_config().chat
-    model = model or cfg.model
+    model = _resolve_model(model or cfg.model)
     temperature = temperature if temperature is not None else cfg.temperature
     if max_tokens is None:
         max_tokens = cfg.max_tokens

--- a/aix/config.py
+++ b/aix/config.py
@@ -86,7 +86,20 @@ __all__ = [
     "configure",
     "using",
     "config_file_path",
+    "resolve_model",
+    "DEFAULT_ALIASES",
 ]
+
+
+# Shipped semantic aliases: intent-level names -> concrete model ids. These are
+# OpenAI-class defaults (so they work with the same OPENAI_API_KEY most users
+# already have); override or extend them via the [aliases] TOML section,
+# ``configure(aliases=...)``, or per-call ``model="..."``.
+DEFAULT_ALIASES = {
+    "fast": "gpt-4.1-mini",  # cheap / low-latency
+    "best": "gpt-5",  # highest quality
+    "cheap": "gpt-4o-mini",  # cheapest
+}
 
 
 def _opt(default: Any, *, flat: str, cast: Callable[[str], Any] = str):
@@ -111,7 +124,7 @@ def _env_name(f) -> str:
 class ChatConfig:
     """Defaults for ``chat`` / ``ask`` / ``prompt_func``."""
 
-    model: str = _opt("gpt-4o-mini", flat="chat_model")
+    model: str = _opt("gpt-4.1-mini", flat="chat_model")
     temperature: float = _opt(1.0, flat="chat_temperature", cast=float)
     max_tokens: Optional[int] = _opt(None, flat="chat_max_tokens", cast=int)
 
@@ -128,7 +141,7 @@ class EmbeddingConfig:
 class ImageConfig:
     """Defaults for ``generate_image`` / ``generate_images``."""
 
-    model: str = _opt("dall-e-2", flat="image_model")
+    model: str = _opt("dall-e-3", flat="image_model")
     size: str = _opt("1024x1024", flat="image_size")
     quality: str = _opt("standard", flat="image_quality")
     num_images: int = _opt(1, flat="image_num_images", cast=int)
@@ -138,7 +151,7 @@ class ImageConfig:
 class AudioConfig:
     """Defaults for ``text_to_speech`` / ``transcribe`` / ``translate_audio``."""
 
-    tts_model: str = _opt("tts-1", flat="tts_model")
+    tts_model: str = _opt("gpt-4o-mini-tts", flat="tts_model")
     tts_voice: str = _opt("alloy", flat="tts_voice")
     tts_speed: float = _opt(1.0, flat="tts_speed", cast=float)
     transcription_model: str = _opt("whisper-1", flat="transcription_model")
@@ -171,7 +184,7 @@ class AixConfig:
     image: ImageConfig = field(default_factory=ImageConfig)
     audio: AudioConfig = field(default_factory=AudioConfig)
     video: VideoConfig = field(default_factory=VideoConfig)
-    aliases: Mapping[str, str] = field(default_factory=dict)
+    aliases: Mapping[str, str] = field(default_factory=lambda: dict(DEFAULT_ALIASES))
 
 
 # --------------------------------------------------------------------------- #
@@ -235,7 +248,8 @@ def load_config(
         attr: _build_subconfig(cls, toml_data.get(attr, {}) or {}, environ)
         for attr, cls in _SECTIONS.items()
     }
-    aliases = dict(toml_data.get("aliases", {}) or {})
+    # Shipped aliases, overlaid by anything in the [aliases] TOML section.
+    aliases = {**DEFAULT_ALIASES, **(toml_data.get("aliases", {}) or {})}
     return AixConfig(aliases=aliases, **sub)
 
 
@@ -277,7 +291,9 @@ def _apply_overrides(base: AixConfig, overrides: Mapping[str, Any]) -> AixConfig
     new_aliases = None
     for key, value in overrides.items():
         if key == "aliases":
-            new_aliases = dict(value)
+            # Merge into existing aliases (add/override individual names) rather
+            # than replacing the whole table, so shipped aliases are preserved.
+            new_aliases = {**base.aliases, **value}
         elif key in _SECTIONS and isinstance(value, Mapping):
             section_updates.setdefault(key, {}).update(value)
         elif key in _FLAT_INDEX:
@@ -330,3 +346,36 @@ def using(**overrides: Any) -> Iterator[AixConfig]:
         yield _active_config
     finally:
         _active_config = previous
+
+
+def resolve_model(
+    model: Optional[str], *, config: Optional[AixConfig] = None
+) -> Optional[str]:
+    """Resolve a semantic alias (``"fast"``, ``"best"``, ...) to a concrete model id.
+
+    Plain substitution: if ``model`` is a key in the active ``aliases`` table it is
+    replaced (following chains, with cycle protection). Anything that is not an
+    alias -- including every literal model id like ``"gpt-4o"`` -- is returned
+    unchanged. ``None`` passes through (callers apply their own default first).
+
+    Note: aliases share a namespace with literal model ids, so an unknown name is
+    treated as a literal id, not an error. Inspect available aliases via
+    ``aix.get_config().aliases``.
+
+    Examples:
+        >>> from aix import config
+        >>> config.resolve_model("fast") in config.DEFAULT_ALIASES.values()
+        True
+        >>> config.resolve_model("gpt-4o")  # not an alias -> unchanged
+        'gpt-4o'
+        >>> config.resolve_model(None) is None
+        True
+    """
+    if model is None:
+        return None
+    aliases = (config or get_config()).aliases
+    seen: set = set()
+    while model in aliases and model not in seen:
+        seen.add(model)
+        model = aliases[model]
+    return model

--- a/aix/embeddings.py
+++ b/aix/embeddings.py
@@ -27,7 +27,11 @@ import hashlib
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from typing import Callable, Optional, Union
 
-from aix.config import get_config as _get_config, EmbeddingConfig as _EmbeddingConfig
+from aix.config import (
+    get_config as _get_config,
+    resolve_model as _resolve_model,
+    EmbeddingConfig as _EmbeddingConfig,
+)
 
 # Import LiteLLM but keep it private
 try:
@@ -98,7 +102,7 @@ def embeddings(
         raise ValueError("Cannot generate embeddings for empty sequence")
 
     # Apply defaults from the active config (explicit args still win)
-    model = model or _get_config().embeddings.model
+    model = _resolve_model(model or _get_config().embeddings.model)
 
     # Build LiteLLM parameters
     litellm_kwargs = {
@@ -431,7 +435,7 @@ def text_cache_key(
     >>> len(text_cache_key("hello"))
     16
     """
-    m = model or _get_config().embeddings.model
+    m = _resolve_model(model or _get_config().embeddings.model)
     h = hashlib.sha1((m + "\x00" + text).encode("utf-8")).hexdigest()
     return h[:hash_len]
 

--- a/aix/image.py
+++ b/aix/image.py
@@ -48,7 +48,11 @@ except ImportError:
 
 # Shipped-default constants, kept for backward compatibility. The *active*
 # defaults are resolved from ``aix.config`` at call time (see aix/config.py).
-from aix.config import get_config as _get_config, ImageConfig as _ImageConfig
+from aix.config import (
+    get_config as _get_config,
+    resolve_model as _resolve_model,
+    ImageConfig as _ImageConfig,
+)
 
 DFLT_IMAGE_MODEL = _ImageConfig().model
 DFLT_IMAGE_SIZE = _ImageConfig().size
@@ -228,7 +232,7 @@ def generate_image(
 
     # Apply defaults from the active config (explicit args still win)
     _img_cfg = _get_config().image
-    model = model or _img_cfg.model
+    model = _resolve_model(model or _img_cfg.model)
     size = size or _img_cfg.size
 
     # Build parameters
@@ -307,7 +311,7 @@ def generate_images(
 
     # Apply defaults from the active config (explicit args still win)
     _img_cfg = _get_config().image
-    model = model or _img_cfg.model
+    model = _resolve_model(model or _img_cfg.model)
     size = size or _img_cfg.size
     n = n or _img_cfg.num_images
 

--- a/aix/prompts.py
+++ b/aix/prompts.py
@@ -37,7 +37,7 @@ from inspect import signature, Parameter
 
 # Import from aix.chat
 from aix.chat import chat, DFLT_CHAT_MODEL
-from aix.config import get_config as _get_config
+from aix.config import get_config as _get_config, resolve_model as _resolve_model
 
 
 def _extract_template_vars(template: str) -> list[str]:
@@ -681,7 +681,7 @@ def constrained_answer(
     # Use LiteLLM's response_format for JSON mode
     # This works across OpenAI, Anthropic (via tools), and other providers
     chat_kwargs = {
-        "model": model or _get_config().chat.model,
+        "model": _resolve_model(model or _get_config().chat.model),
         "response_format": {"type": "json_object"},
     }
     if temperature is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,11 +8,13 @@ from aix import config
 from aix.config import (
     AixConfig,
     ChatConfig,
+    DEFAULT_ALIASES,
     load_config,
     get_config,
     set_config,
     configure,
     using,
+    resolve_model,
 )
 
 
@@ -22,10 +24,10 @@ def test_shipped_defaults():
     assert c.chat.model == ChatConfig().model
     assert c.chat.temperature == 1.0
     assert c.embeddings.model == "text-embedding-3-small"
-    assert c.image.model == "dall-e-2"
-    assert c.audio.tts_model == "tts-1"
+    assert c.image.model == "dall-e-3"
+    assert c.audio.tts_model == "gpt-4o-mini-tts"
     assert c.audio.transcription_model == "whisper-1"
-    assert c.aliases == {}
+    assert c.aliases == DEFAULT_ALIASES
 
 
 def test_env_layer_overrides_defaults():
@@ -54,7 +56,8 @@ def test_toml_layer_and_env_precedence():
     assert c.chat.model == "env/model"
     assert c.chat.temperature == 0.9  # from toml (no env override)
     assert c.image.model == "toml/image"
-    assert c.aliases == {"best": "x/y"}
+    # TOML aliases overlay the shipped defaults (override 'best', keep the rest)
+    assert c.aliases == {**DEFAULT_ALIASES, "best": "x/y"}
 
 
 def test_missing_toml_is_ignored():
@@ -118,6 +121,42 @@ def test_config_is_immutable():
 def test_set_config_type_checked(restore_active_config):
     with pytest.raises(TypeError):
         set_config({"chat": {"model": "x"}})  # not an AixConfig
+
+
+def test_resolve_model_aliases(restore_active_config):
+    # Shipped aliases resolve to concrete ids
+    assert resolve_model("fast") == DEFAULT_ALIASES["fast"]
+    assert resolve_model("best") == DEFAULT_ALIASES["best"]
+    # Non-alias strings (literal model ids) pass through unchanged
+    assert resolve_model("gpt-4o") == "gpt-4o"
+    assert resolve_model("openrouter/anthropic/claude-3.5-sonnet") == (
+        "openrouter/anthropic/claude-3.5-sonnet"
+    )
+    # None passes through
+    assert resolve_model(None) is None
+
+
+def test_resolve_model_custom_alias(restore_active_config):
+    configure(aliases={"smart": "anthropic/claude-sonnet-4"})
+    assert resolve_model("smart") == "anthropic/claude-sonnet-4"
+    # configure merges: shipped aliases are preserved
+    assert resolve_model("fast") == DEFAULT_ALIASES["fast"]
+
+
+def test_resolve_model_chain_and_cycle(restore_active_config):
+    # Chains resolve transitively
+    configure(aliases={"a": "b", "b": "gpt-4o"})
+    assert resolve_model("a") == "gpt-4o"
+    # Cycles terminate instead of looping forever
+    configure(aliases={"x": "y", "y": "x"})
+    assert resolve_model("x") in {"x", "y"}
+
+
+def test_alias_used_in_using_block(restore_active_config):
+    with using(aliases={"fast": "custom/fast"}):
+        assert resolve_model("fast") == "custom/fast"
+    # restored to shipped default outside the block
+    assert resolve_model("fast") == DEFAULT_ALIASES["fast"]
 
 
 def test_active_config_drives_function_defaults(restore_active_config):


### PR DESCRIPTION
## Summary

Implements **#25** on top of the central config (#23/#26): refreshes the shipped default models and adds **semantic alias resolution**.

## Refreshed defaults

All ids verified present in `litellm.model_cost`:

| Function | Old | New | Why |
|---|---|---|---|
| chat | `gpt-4o-mini` | `gpt-4.1-mini` | current mini-class, cheap, same provider |
| image | `dall-e-2` | `dall-e-3` | safe upgrade — `gpt-image-1` needs OpenAI org verification, would break out-of-box |
| tts | `tts-1` | `gpt-4o-mini-tts` | modern, cheaper, drop-in; `alloy` voice still valid |
| embeddings | `text-embedding-3-small` | *(unchanged)* | still current |
| transcription | `whisper-1` | *(unchanged)* | `gpt-4o-transcribe` lacks the verbose-timestamp + translation-endpoint features `transcribe_with_timestamps`/`translate_audio` rely on |

## Semantic aliases

`config.resolve_model()` maps intent-level names to concrete ids. Shipped: `fast` -> `gpt-4.1-mini`, `best` -> `gpt-5`, `cheap` -> `gpt-4o-mini`.

- Plain substitution: follows chains, with cycle protection.
- Applied at every model-resolution site (chat, embeddings, image, audio, prompts), so `chat("...", model="best")` works everywhere.
- Aliases **merge** with TOML `[aliases]` and `configure(aliases=...)` overrides (shipped set preserved).
- Exposed as `aix.resolve_model`.

### Design note (deviation from the issue's acceptance list)

The issue listed *"unknown alias raises a clear error listing available aliases."* That isn't feasible as written: aliases share a namespace with literal model ids, so a non-matching string (e.g. `"gpt-4o"`, `"openrouter/anthropic/..."`) **must** pass through as a literal id — otherwise every real model name would have to be a registered alias. Implemented as plain substitution with pass-through instead; available aliases are inspectable via `aix.get_config().aliases`.

## Testing

- New cases: alias resolution, custom alias + merge, chain + cycle, `using()` scoping; updated shipped-default assertions.
- Full suite: **155 passed**. Doctests in `config.py` pass.

Closes #25
