### PR TITLE
Unified, discoverable credential resolution + preflight (#24)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,9 @@ Thank you for your interest in contributing to AIX! This document provides guide
    pip install pytest pytest-cov pytest-mock ruff
    ```
 
-4. **Set up API keys** (for testing):
+4. **Set up API keys** (only for live/integration testing — the unit suite mocks
+   the provider backend and injects dummy keys automatically, so it runs without
+   any real credentials):
    ```bash
    export OPENAI_API_KEY=your-key-here
    export ANTHROPIC_API_KEY=your-key-here

--- a/README.md
+++ b/README.md
@@ -142,10 +142,69 @@ best = "anthropic/claude-sonnet-4"
 Find the active path with `aix.config.config_file_path()`. Environment variables
 override file values; explicit call arguments override everything.
 
-> **Note on credentials:** API keys are currently discovered by the provider
-> backend (LiteLLM) from standard environment variables such as `OPENAI_API_KEY`,
-> `ANTHROPIC_API_KEY`, and `OPENROUTER_API_KEY`. A unified, discoverable key
-> resolver with actionable error messages is in progress.
+## Providing credentials
+
+Every key-requiring function (`chat`, `embeddings`, `generate_image`,
+`text_to_speech`, `transcribe`, `generate_video`, ...) resolves its API key
+through one documented path. The resolution order, highest precedence first:
+
+1. **Explicit argument** — `chat("hi", api_key="sk-...")` (keyword-only, on every
+   key-requiring function).
+2. **Provider environment variable** — the canonical name for the model's
+   provider (see the table below). A project `.env` is *softly* discovered when
+   `python-dotenv` is installed; an explicitly exported variable always wins over
+   a `.env` value.
+3. **AIX config store** — a per-user store in your app-config folder, keyed by the
+   canonical env-var name (so the store and the env layer share one namespace).
+4. **(Interactive only) prompt + persist** — in a REPL, AIX can ask once and save
+   the key to the config store.
+
+The provider is inferred from the model id, so you rarely name it yourself:
+
+```python
+import aix
+
+aix.chat("Hello", model="gpt-4o")          # uses OPENAI_API_KEY
+aix.chat("Hi", model="claude-sonnet-4")    # uses ANTHROPIC_API_KEY
+aix.chat("Yo", api_key="sk-...")           # explicit key wins
+
+# Check what's discoverable (values are never shown — availability only):
+aix.check_keys()
+# {'openai': {'available': True, 'env_vars': ['OPENAI_API_KEY'], 'source': 'env'}, ...}
+```
+
+When a required key is missing, you get an actionable `MissingCredentialError`
+naming *which* key, *how* to set it, and *where* to get one — instead of a cryptic
+provider error:
+
+```python
+>>> aix.chat("hi", model="gpt-4o")
+aix.credentials.MissingCredentialError: No API key found for provider 'openai'
+(model 'gpt-4o'). Set OPENAI_API_KEY via one of:
+  - export it:  export OPENAI_API_KEY=...
+  - add it to a .env file in your project, or
+  - store it in the AIX config store under the key 'OPENAI_API_KEY'.
+Get a key at: https://platform.openai.com/api-keys
+```
+
+### Provider → environment variable
+
+| Provider | Environment variable | Get a key |
+|---|---|---|
+| OpenAI | `OPENAI_API_KEY` | https://platform.openai.com/api-keys |
+| Anthropic | `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys |
+| Google Gemini | `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | https://aistudio.google.com/apikey |
+| OpenRouter | `OPENROUTER_API_KEY` | https://openrouter.ai/keys |
+| Mistral | `MISTRAL_API_KEY` | https://console.mistral.ai/api-keys/ |
+| Cohere | `COHERE_API_KEY` | https://dashboard.cohere.com/api-keys |
+| Groq | `GROQ_API_KEY` | https://console.groq.com/keys |
+| DeepSeek | `DEEPSEEK_API_KEY` | https://platform.deepseek.com/api_keys |
+| xAI | `XAI_API_KEY` | https://console.x.ai/ |
+| Perplexity | `PERPLEXITYAI_API_KEY` | https://www.perplexity.ai/settings/api |
+| Runway (video) | `RUNWAY_API_KEY` | https://app.runwayml.com/ |
+
+The full mapping is `aix.PROVIDER_ENV_VARS`. Keys are never logged, and the config
+store lives in your user app-config folder — never in the repo.
 
 ## Core Features
 

--- a/aix/__init__.py
+++ b/aix/__init__.py
@@ -56,6 +56,15 @@ from aix.config import (
     resolve_model,
 )
 
+# Credentials (unified, discoverable API-key resolution)
+from aix.credentials import (
+    resolve_api_key,
+    check_requirements,
+    check_keys,
+    MissingCredentialError,
+    PROVIDER_ENV_VARS,
+)
+
 # Core interfaces (new clean API)
 from aix.chat import chat, ask, chat_with_history, ChatSession
 from aix.embeddings import (
@@ -131,6 +140,12 @@ __all__ = [
     "using",
     "load_config",
     "resolve_model",
+    # Credentials
+    "resolve_api_key",
+    "check_requirements",
+    "check_keys",
+    "MissingCredentialError",
+    "PROVIDER_ENV_VARS",
     # Core chat
     "chat",
     "ask",

--- a/aix/ai_models/sources.py
+++ b/aix/ai_models/sources.py
@@ -137,12 +137,16 @@ class ProviderAPISource(ModelSource):
         self,
         provider_name: str,
         *,
-        api_key: str,
+        api_key: str = None,
         base_url: str = "https://api.openai.com/v1",
         timeout: int = 30,
     ):
+        from aix.credentials import resolve_api_key
+
         self._provider_name = provider_name
-        self._api_key = api_key
+        # Resolve through the unified credential path (explicit arg > env/.env >
+        # AIX config store) instead of requiring the key to be passed in.
+        self._api_key = resolve_api_key(provider_name, api_key=api_key)
         self._base_url = base_url
         self._timeout = timeout
 

--- a/aix/audio.py
+++ b/aix/audio.py
@@ -31,6 +31,10 @@ except ImportError:
 
 # Shipped-default constants, kept for backward compatibility. The *active*
 # defaults are resolved from ``aix.config`` at call time (see aix/config.py).
+from aix.credentials import (
+    resolve_api_key as _resolve_api_key,
+    requires_credentials as _requires_credentials,
+)
 from aix.config import (
     get_config as _get_config,
     resolve_model as _resolve_model,
@@ -188,6 +192,7 @@ class TranscriptionResult:
         )
 
 
+@_requires_credentials(lambda: _get_config().audio.tts_model)
 def text_to_speech(
     text: str,
     *,
@@ -195,6 +200,7 @@ def text_to_speech(
     voice: str = None,
     speed: float = None,
     response_format: str = "mp3",
+    api_key: str = None,
     **kwargs,
 ) -> GeneratedAudio:
     """Convert text to speech audio.
@@ -253,6 +259,11 @@ def text_to_speech(
         "speed": speed,
     }
 
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
+
     # Add additional kwargs
     params.update(kwargs)
 
@@ -271,6 +282,7 @@ def text_to_speech(
     )
 
 
+@_requires_credentials(lambda: _get_config().audio.transcription_model)
 def transcribe(
     audio: Union[str, Path, BinaryIO, bytes],
     *,
@@ -280,6 +292,7 @@ def transcribe(
     response_format: str = "text",
     temperature: float = None,
     timestamp_granularities: list[str] = None,
+    api_key: str = None,
     **kwargs,
 ) -> Union[str, TranscriptionResult]:
     """Transcribe audio to text.
@@ -361,6 +374,11 @@ def transcribe(
     if timestamp_granularities:
         params["timestamp_granularities"] = timestamp_granularities
 
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
+
     # Add additional kwargs
     params.update(kwargs)
 
@@ -431,11 +449,13 @@ def transcribe_with_timestamps(
     )
 
 
+@_requires_credentials(lambda: _get_config().audio.transcription_model)
 def translate_audio(
     audio: Union[str, Path, BinaryIO, bytes],
     *,
     model: str = None,
     prompt: str = None,
+    api_key: str = None,
     **kwargs,
 ) -> str:
     """Translate audio from any language to English.
@@ -486,6 +506,11 @@ def translate_audio(
 
     if prompt:
         params["prompt"] = prompt
+
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
 
     params.update(kwargs)
 

--- a/aix/chat.py
+++ b/aix/chat.py
@@ -37,6 +37,10 @@ from aix.config import (
     resolve_model as _resolve_model,
     ChatConfig as _ChatConfig,
 )
+from aix.credentials import (
+    resolve_api_key as _resolve_api_key,
+    requires_credentials as _requires_credentials,
+)
 
 # Import LiteLLM but keep it private - users shouldn't call it directly
 try:
@@ -127,6 +131,7 @@ def _extract_text_from_stream(stream: Iterable) -> Iterable[str]:
             continue
 
 
+@_requires_credentials(lambda: _get_config().chat.model)
 def chat(
     prompt: Union[str, Iterable[dict]],
     *,
@@ -134,6 +139,7 @@ def chat(
     temperature: float = None,
     max_tokens: int = None,
     stream: bool = False,
+    api_key: str = None,
     **kwargs,
 ) -> Union[str, Iterable[str]]:
     """Send a chat prompt and get a response.
@@ -151,6 +157,8 @@ def chat(
         max_tokens: Maximum tokens to generate. If None, uses model's default.
         stream: If True, return an iterator of text chunks. If False, return
             complete response as string.
+        api_key: Explicit API key. If None, resolved from the environment / .env
+            / AIX config store for the model's provider (see aix.credentials).
         **kwargs: Additional provider-specific parameters passed to LiteLLM
 
     Returns:
@@ -207,6 +215,12 @@ def chat(
 
     if max_tokens is not None:
         litellm_kwargs["max_tokens"] = max_tokens
+
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    # When None, fall back to LiteLLM's own implicit reading.
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        litellm_kwargs["api_key"] = resolved_key
 
     # Add any additional provider-specific kwargs
     litellm_kwargs.update(kwargs)

--- a/aix/credentials.py
+++ b/aix/credentials.py
@@ -1,0 +1,451 @@
+"""Unified, discoverable API-key / secret resolution for AIX.
+
+Every key-requiring function in AIX (``chat``, ``embeddings``, ``generate_image``,
+``text_to_speech``, ``transcribe``, ``generate_video``, ...) resolves its
+credentials through a single, documented path -- instead of relying on LiteLLM's
+implicit environment reading, scattered ``os.getenv`` calls, or an orphaned
+config getter.
+
+Resolution layers, highest precedence first:
+
+1. **Explicit argument** -- ``chat(..., api_key=...)``.
+2. **Provider environment variable** -- the canonical name for the inferred
+   provider (e.g. ``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``).
+   A project ``.env`` is *softly* discovered when ``python-dotenv`` is installed
+   (no hard dependency); explicit env vars always win over ``.env`` values.
+3. **AIX config store** -- a config2py central store in the user app-config
+   folder, keyed by the canonical env-var name (so the store and the env layer
+   share one namespace). See :mod:`aix.util`.
+4. **(REPL only) interactive prompt** -- when ``prompt_if_missing=True`` *and*
+   running interactively, ask once and persist to the config store.
+
+The provider for a model id is inferred via LiteLLM's ``get_llm_provider``; a
+small curated :data:`PROVIDER_ENV_VARS` table maps each documented provider to
+its env-var name(s) and console URL.
+
+When a required key is genuinely absent, :func:`check_requirements` raises
+:class:`MissingCredentialError` -- naming *which* key is missing, *how* to set
+it, and *where* to obtain one -- rather than letting a cryptic, provider-specific
+LiteLLM error surface late. This preflight is wired in via the
+:func:`requires_credentials` decorator so error-raising stays separate from
+business logic.
+
+Examples:
+    >>> from aix.credentials import resolve_api_key, PROVIDER_ENV_VARS
+    >>> resolve_api_key("gpt-4o", api_key="sk-explicit")  # explicit wins
+    'sk-explicit'
+    >>> "openai" in PROVIDER_ENV_VARS
+    True
+
+Security:
+    Resolved key *values* are never logged or returned by diagnostics;
+    :func:`check_keys` reports availability only. Keys live in the user
+    app-config folder, never in the repo.
+"""
+
+import os
+from collections.abc import Iterable
+from functools import wraps
+from typing import Callable, Optional, Union
+
+__all__ = [
+    "PROVIDER_ENV_VARS",
+    "PROVIDER_CONSOLE_URLS",
+    "MissingCredentialError",
+    "infer_provider",
+    "provider_env_vars",
+    "resolve_api_key",
+    "check_requirements",
+    "requires_credentials",
+    "check_keys",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Provider <-> env-var mapping (curated table for the providers AIX documents)
+# --------------------------------------------------------------------------- #
+
+# Provider name (as inferred by ``litellm.get_llm_provider``) -> canonical env
+# var name(s). When more than one is listed, they are tried in order; the first
+# is treated as the *canonical* name for error messages and the config store.
+PROVIDER_ENV_VARS: dict[str, Union[str, list[str]]] = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    # LiteLLM uses GEMINI_API_KEY; the legacy google.generativeai SDK uses
+    # GOOGLE_API_KEY -- accept either so both paths resolve the same secret.
+    "gemini": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    "vertex_ai": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
+    "google": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
+    "openrouter": "OPENROUTER_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+    "cohere": "COHERE_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "xai": "XAI_API_KEY",
+    "perplexity": "PERPLEXITYAI_API_KEY",
+    "together_ai": "TOGETHERAI_API_KEY",
+    # Video providers (used by aix.video / aix.ai_models.sources).
+    "runway": "RUNWAY_API_KEY",
+    "pika": "PIKA_API_KEY",
+}
+
+# Provider -> where to obtain a key. Only the providers AIX documents are listed;
+# a missing entry simply omits the "get one at" hint.
+PROVIDER_CONSOLE_URLS: dict[str, str] = {
+    "openai": "https://platform.openai.com/api-keys",
+    "anthropic": "https://console.anthropic.com/settings/keys",
+    "gemini": "https://aistudio.google.com/apikey",
+    "vertex_ai": "https://console.cloud.google.com/apis/credentials",
+    "google": "https://aistudio.google.com/apikey",
+    "openrouter": "https://openrouter.ai/keys",
+    "mistral": "https://console.mistral.ai/api-keys/",
+    "cohere": "https://dashboard.cohere.com/api-keys",
+    "groq": "https://console.groq.com/keys",
+    "deepseek": "https://platform.deepseek.com/api_keys",
+    "xai": "https://console.x.ai/",
+    "perplexity": "https://www.perplexity.ai/settings/api",
+    "runway": "https://app.runwayml.com/",
+}
+
+
+def provider_env_vars(provider: str) -> list[str]:
+    """Return the env-var name(s) for ``provider`` as a list (possibly empty).
+
+    Examples:
+        >>> provider_env_vars("openai")
+        ['OPENAI_API_KEY']
+        >>> provider_env_vars("gemini")
+        ['GEMINI_API_KEY', 'GOOGLE_API_KEY']
+        >>> provider_env_vars("totally-unknown-provider")
+        []
+    """
+    names = PROVIDER_ENV_VARS.get(provider)
+    if names is None:
+        return []
+    return [names] if isinstance(names, str) else list(names)
+
+
+# --------------------------------------------------------------------------- #
+# Provider inference
+# --------------------------------------------------------------------------- #
+
+
+def infer_provider(model_or_provider: Optional[str]) -> Optional[str]:
+    """Infer the provider name from a model id (or pass through a provider name).
+
+    Uses LiteLLM's ``get_llm_provider`` when available. If ``model_or_provider``
+    is already a known provider name (a key in :data:`PROVIDER_ENV_VARS`), it is
+    returned as-is. Returns ``None`` if the provider cannot be determined.
+
+    Examples:
+        >>> infer_provider("gpt-4o")
+        'openai'
+        >>> infer_provider("openrouter")  # already a provider name
+        'openrouter'
+        >>> infer_provider(None) is None
+        True
+    """
+    if not model_or_provider:
+        return None
+    # An explicit provider name short-circuits inference.
+    if model_or_provider in PROVIDER_ENV_VARS:
+        return model_or_provider
+    try:
+        from litellm import get_llm_provider
+
+        # Returns (model, provider, dynamic_api_key, api_base).
+        _, provider, *_ = get_llm_provider(model_or_provider)
+        return provider or None
+    except Exception:
+        # LiteLLM missing, or it could not classify the id. Fall back to None;
+        # the caller surfaces an actionable error rather than a cryptic one.
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Store + .env access (non-interactive on the hot path)
+# --------------------------------------------------------------------------- #
+
+_dotenv_loaded = False
+
+
+def _maybe_load_dotenv() -> None:
+    """Softly load a project ``.env`` into ``os.environ`` (once), if dotenv exists.
+
+    No-op when ``python-dotenv`` is not installed (it is not a hard dependency).
+    Existing environment variables are never overridden, so an explicitly
+    exported key always wins over a ``.env`` value.
+    """
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+    _dotenv_loaded = True  # mark first so a missing dotenv is not retried
+    try:
+        from dotenv import load_dotenv, find_dotenv
+
+        load_dotenv(find_dotenv(usecwd=True), override=False)
+    except Exception:
+        # dotenv absent or no .env found -- degrade to export-only discovery.
+        pass
+
+
+def _lookup_store(name: str) -> Optional[str]:
+    """Read ``name`` from the AIX config2py store without prompting.
+
+    Reads the central store directly (``get_config.configs``) rather than calling
+    the composed getter, which may prompt interactively in a REPL. Returns
+    ``None`` if absent or unreadable.
+    """
+    try:
+        from aix.util import get_config as _aix_config_getter
+
+        store = _aix_config_getter.configs
+        value = store.get(name)
+    except Exception:
+        return None
+    if value is None:
+        return None
+    value = value.strip()  # text-file stores can append a trailing newline
+    return value or None
+
+
+def _prompt_and_persist(name: str) -> Optional[str]:
+    """Ask the user for ``name`` and persist it to the store (REPL only).
+
+    Delegates to the config2py getter, which prompts and stores when interactive.
+    Returns ``None`` if no value is obtained.
+    """
+    try:
+        from aix.util import get_config as _aix_config_getter
+
+        value = _aix_config_getter(name)
+    except Exception:
+        return None
+    if not value:
+        return None
+    return value.strip() or None
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+def resolve_api_key(
+    model_or_provider: Optional[str],
+    *,
+    api_key: Optional[str] = None,
+    prompt_if_missing: bool = False,
+) -> Optional[str]:
+    """Resolve an API key for ``model_or_provider`` through the documented layers.
+
+    Layers, highest precedence first: explicit ``api_key`` argument, provider
+    environment variable (with soft ``.env`` discovery), the AIX config store,
+    and -- only when ``prompt_if_missing`` is true *and* running interactively --
+    an interactive prompt that persists the answer.
+
+    Args:
+        model_or_provider: A model id (provider inferred via LiteLLM) or a
+            provider name directly (e.g. ``"openai"``).
+        api_key: An explicit key; when given (non-empty) it is returned verbatim.
+        prompt_if_missing: If true, fall back to a REPL prompt + persist when no
+            key is found elsewhere. Off by default so the common path never
+            blocks on input.
+
+    Returns:
+        The resolved key, or ``None`` if genuinely absent.
+
+    Examples:
+        >>> resolve_api_key("gpt-4o", api_key="sk-explicit")
+        'sk-explicit'
+    """
+    # 1. Explicit argument always wins.
+    if api_key:
+        return api_key
+
+    provider = infer_provider(model_or_provider)
+    env_names = provider_env_vars(provider) if provider else []
+
+    # 2. Provider environment variable (soft .env discovery first).
+    _maybe_load_dotenv()
+    for name in env_names:
+        value = os.environ.get(name)
+        if value:
+            return value
+
+    # 3. AIX config store (non-interactive read), keyed by env-var name.
+    for name in env_names:
+        value = _lookup_store(name)
+        if value:
+            return value
+
+    # 4. (REPL only) prompt + persist, using the canonical env-var name.
+    if prompt_if_missing and env_names:
+        return _prompt_and_persist(env_names[0])
+
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Preflight + informative errors
+# --------------------------------------------------------------------------- #
+
+
+class MissingCredentialError(Exception):
+    """Raised when a required API key cannot be resolved.
+
+    The message names which key is missing, how to set it, and (when known)
+    where to obtain one. Key *values* are never included.
+    """
+
+    def __init__(
+        self,
+        model_or_provider: Optional[str],
+        *,
+        provider: Optional[str] = None,
+        env_names: Optional[list[str]] = None,
+    ):
+        self.model_or_provider = model_or_provider
+        self.provider = provider or infer_provider(model_or_provider)
+        self.env_names = (
+            env_names
+            if env_names is not None
+            else (provider_env_vars(self.provider) if self.provider else [])
+        )
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
+        provider = self.provider or "the selected provider"
+        if self.env_names:
+            canonical = self.env_names[0]
+            alt = (
+                f" (or {', '.join(self.env_names[1:])})"
+                if len(self.env_names) > 1
+                else ""
+            )
+            how = (
+                f"  - export it:  export {canonical}=...{alt}\n"
+                f"  - add it to a .env file in your project, or\n"
+                f"  - store it in the AIX config store under the key "
+                f"{canonical!r}."
+            )
+            head = (
+                f"No API key found for provider {provider!r} "
+                f"(model {self.model_or_provider!r}). "
+                f"Set {canonical}{alt} via one of:"
+            )
+        else:
+            canonical = None
+            how = (
+                "  - pass it explicitly:  api_key=...\n"
+                "  - or set the provider's documented environment variable."
+            )
+            head = (
+                f"No API key found for {self.model_or_provider!r}, and the "
+                f"provider could not be determined. Provide a key directly:"
+            )
+        url = PROVIDER_CONSOLE_URLS.get(self.provider or "")
+        where = f"\nGet a key at: {url}" if url else ""
+        return f"{head}\n{how}{where}"
+
+
+def check_requirements(
+    model_or_provider: Optional[str], *, api_key: Optional[str] = None
+) -> bool:
+    """Presence-only preflight: ensure a key for ``model_or_provider`` is resolvable.
+
+    Does *not* validate the key over the network -- only that one is discoverable
+    via :func:`resolve_api_key` (explicit arg, env/.env, or store). Raises
+    :class:`MissingCredentialError` with actionable guidance when absent.
+
+    Returns ``True`` when a key is available.
+
+    Examples:
+        >>> check_requirements("gpt-4o", api_key="sk-explicit")
+        True
+    """
+    if resolve_api_key(model_or_provider, api_key=api_key) is not None:
+        return True
+    raise MissingCredentialError(model_or_provider)
+
+
+def requires_credentials(default_model: Callable[[], Optional[str]]):
+    """Decorator: preflight credentials before the wrapped function runs.
+
+    Separates error-raising from business logic (per the AIX coding principles).
+    The wrapped function is expected to take keyword-only ``model`` and
+    ``api_key`` parameters. ``default_model`` is a zero-arg callable returning the
+    model the function would default to (read from the active config at call
+    time), so the preflight checks the *same* model the function will use.
+
+    Args:
+        default_model: Callable returning the default model id when the caller
+            passes ``model=None``.
+
+    Examples:
+        >>> from aix import config
+        >>> @requires_credentials(lambda: config.get_config().chat.model)
+        ... def f(*, model=None, api_key=None):
+        ...     return "ran"
+        >>> f(api_key="sk-explicit")
+        'ran'
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            model = kwargs.get("model") or default_model()
+            check_requirements(model, api_key=kwargs.get("api_key"))
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+# --------------------------------------------------------------------------- #
+# Doctor / diagnostics
+# --------------------------------------------------------------------------- #
+
+
+def check_keys(providers: Optional[Iterable[str]] = None) -> dict[str, dict]:
+    """Report, per provider, whether a usable API key is discoverable.
+
+    Never returns or logs key *values* -- only availability and the env-var
+    name(s) checked. Useful for quick setup debugging.
+
+    Args:
+        providers: Providers to check; defaults to every provider in
+            :data:`PROVIDER_ENV_VARS`.
+
+    Returns:
+        Mapping ``provider -> {"available": bool, "env_vars": [...],
+        "source": <where-found-or-None>}``. ``source`` is ``"env"``, ``"store"``,
+        or ``None`` (never the value itself).
+
+    Examples:
+        >>> report = check_keys(["openai"])  # doctest: +SKIP
+        >>> report["openai"]["available"]  # doctest: +SKIP
+        True
+    """
+    names = list(providers) if providers is not None else list(PROVIDER_ENV_VARS)
+    _maybe_load_dotenv()
+    report: dict[str, dict] = {}
+    for provider in names:
+        env_names = provider_env_vars(provider)
+        source = None
+        for name in env_names:
+            if os.environ.get(name):
+                source = "env"
+                break
+        if source is None:
+            for name in env_names:
+                if _lookup_store(name):
+                    source = "store"
+                    break
+        report[provider] = {
+            "available": source is not None,
+            "env_vars": env_names,
+            "source": source,
+        }
+    return report

--- a/aix/embeddings.py
+++ b/aix/embeddings.py
@@ -32,6 +32,10 @@ from aix.config import (
     resolve_model as _resolve_model,
     EmbeddingConfig as _EmbeddingConfig,
 )
+from aix.credentials import (
+    resolve_api_key as _resolve_api_key,
+    requires_credentials as _requires_credentials,
+)
 
 # Import LiteLLM but keep it private
 try:
@@ -46,8 +50,9 @@ DFLT_EMBEDDING_MODEL = _EmbeddingConfig().model
 DFLT_BATCH_SIZE = _EmbeddingConfig().batch_size
 
 
+@_requires_credentials(lambda: _get_config().embeddings.model)
 def embeddings(
-    segments: Iterable[str], *, model: str = None, **kwargs
+    segments: Iterable[str], *, model: str = None, api_key: str = None, **kwargs
 ) -> Iterable[Sequence[float]]:
     """Generate embeddings for multiple text segments.
 
@@ -58,6 +63,8 @@ def embeddings(
         segments: Iterable of text strings to embed
         model: Model identifier (e.g., 'text-embedding-3-small', 'text-embedding-ada-002',
             'openrouter/openai/text-embedding-3-small'). If None, uses default.
+        api_key: Explicit API key. If None, resolved from the environment / .env
+            / AIX config store for the model's provider (see aix.credentials).
         **kwargs: Additional provider-specific parameters passed to LiteLLM
 
     Yields:
@@ -109,6 +116,11 @@ def embeddings(
         "model": model,
         "input": segments_list,
     }
+
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        litellm_kwargs["api_key"] = resolved_key
 
     # Add any additional provider-specific kwargs
     litellm_kwargs.update(kwargs)

--- a/aix/gen_ai/google_genai.py
+++ b/aix/gen_ai/google_genai.py
@@ -1,7 +1,7 @@
 """Google GenAI API functionality."""
 
 from contextlib import suppress
-from aix.util import get_config
+from aix.credentials import resolve_api_key
 
 name = "google"
 required_packages = ["google.generativeai"]
@@ -20,7 +20,9 @@ with suppress(ModuleNotFoundError, ImportError):
     import google.generativeai as genai
     from i2 import Sig
 
-    genai.configure(api_key=get_config(Const.GOOGLE_API_KEY))
+    # Resolve via the unified credential path (env / .env / AIX config store).
+    # Non-interactive at import time so importing the package never blocks.
+    genai.configure(api_key=resolve_api_key("google"))
 
     # TODO: Add Literal for model
     _sig = Sig(genai.GenerativeModel.generate_content)

--- a/aix/image.py
+++ b/aix/image.py
@@ -48,6 +48,10 @@ except ImportError:
 
 # Shipped-default constants, kept for backward compatibility. The *active*
 # defaults are resolved from ``aix.config`` at call time (see aix/config.py).
+from aix.credentials import (
+    resolve_api_key as _resolve_api_key,
+    requires_credentials as _requires_credentials,
+)
 from aix.config import (
     get_config as _get_config,
     resolve_model as _resolve_model,
@@ -178,6 +182,7 @@ class GeneratedImage:
         return f"GeneratedImage(model={self.model}, url={bool(self.url)})"
 
 
+@_requires_credentials(lambda: _get_config().image.model)
 def generate_image(
     prompt: str,
     *,
@@ -186,6 +191,7 @@ def generate_image(
     quality: str = None,
     style: str = None,
     response_format: str = "url",
+    api_key: str = None,
     **kwargs,
 ) -> GeneratedImage:
     """Generate a single image from a text prompt.
@@ -197,6 +203,8 @@ def generate_image(
         quality: Image quality ('standard' or 'hd' for DALL-E 3)
         style: Image style ('vivid' or 'natural' for DALL-E 3)
         response_format: Format of response ('url' or 'b64_json')
+        api_key: Explicit API key. If None, resolved from the environment / .env
+            / AIX config store for the model's provider (see aix.credentials).
         **kwargs: Additional provider-specific parameters
 
     Returns:
@@ -249,6 +257,11 @@ def generate_image(
     if style:
         params["style"] = style
 
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
+
     # Add additional kwargs
     params.update(kwargs)
 
@@ -267,6 +280,7 @@ def generate_image(
     )
 
 
+@_requires_credentials(lambda: _get_config().image.model)
 def generate_images(
     prompt: str,
     *,
@@ -276,6 +290,7 @@ def generate_images(
     quality: str = None,
     style: str = None,
     response_format: str = "url",
+    api_key: str = None,
     **kwargs,
 ) -> list[GeneratedImage]:
     """Generate multiple images from a text prompt.
@@ -329,6 +344,11 @@ def generate_images(
     if style:
         params["style"] = style
 
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
+
     # Add additional kwargs
     params.update(kwargs)
 
@@ -351,6 +371,7 @@ def generate_images(
     return images
 
 
+@_requires_credentials(lambda: "dall-e-2")
 def edit_image(
     image_path: Union[str, Path],
     prompt: str,
@@ -359,6 +380,7 @@ def edit_image(
     model: str = None,
     size: str = None,
     n: int = 1,
+    api_key: str = None,
     **kwargs,
 ) -> Union[GeneratedImage, list[GeneratedImage]]:
     """Edit an existing image based on a prompt.
@@ -413,6 +435,11 @@ def edit_image(
     if size:
         params["size"] = size
 
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(params["model"], api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
+
     params.update(kwargs)
 
     # Call LiteLLM (using custom_llm_provider for edits)
@@ -433,12 +460,14 @@ def edit_image(
     return images[0] if n == 1 else images
 
 
+@_requires_credentials(lambda: "dall-e-2")
 def create_variation(
     image_path: Union[str, Path],
     *,
     model: str = None,
     size: str = None,
     n: int = 1,
+    api_key: str = None,
     **kwargs,
 ) -> Union[GeneratedImage, list[GeneratedImage]]:
     """Create variations of an existing image.
@@ -482,6 +511,11 @@ def create_variation(
 
     if size:
         params["size"] = size
+
+    # Resolve and inject the API key (explicit arg > env/.env > config store).
+    resolved_key = _resolve_api_key(params["model"], api_key=api_key)
+    if resolved_key is not None:
+        params["api_key"] = resolved_key
 
     params.update(kwargs)
 

--- a/aix/video.py
+++ b/aix/video.py
@@ -164,6 +164,7 @@ def generate_video(
     aspect_ratio: str = None,
     style: str = None,
     seed: int = None,
+    api_key: str = None,
     **kwargs,
 ) -> GeneratedVideo:
     """Generate a video from a text prompt.
@@ -181,6 +182,8 @@ def generate_video(
         aspect_ratio: Aspect ratio ('16:9', '9:16', '1:1', etc.)
         style: Video style hint (provider-specific)
         seed: Random seed for reproducibility
+        api_key: Explicit API key for the video provider. If None, resolved from
+            the environment / .env / AIX config store (see aix.credentials).
         **kwargs: Additional provider-specific parameters
 
     Returns:
@@ -400,16 +403,15 @@ def get_available_providers() -> list[str]:
         >>> print(providers)  # doctest: +SKIP
         ['runway', 'pika']
     """
+    from aix.credentials import resolve_api_key
+
     available = []
 
-    # Check for Runway
-    import os
-
-    if os.getenv("RUNWAY_API_KEY"):
+    # Check for Runway / Pika via the unified credential resolver (env / .env /
+    # AIX config store) rather than reading os.environ directly.
+    if resolve_api_key("runway"):
         available.append("runway")
-
-    # Check for Pika
-    if os.getenv("PIKA_API_KEY"):
+    if resolve_api_key("pika"):
         available.append("pika")
 
     # Check for Stable Diffusion

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,14 @@ export ANTHROPIC_API_KEY=your-key-here
 export OPENROUTER_API_KEY=your-key-here
 ```
 
+AIX resolves keys in this order: explicit `api_key=` argument → provider
+environment variable (a project `.env` is picked up when `python-dotenv` is
+installed) → the per-user AIX config store. Check what's discoverable with
+`aix.check_keys()`, and see the
+[Providing credentials](../README.md#providing-credentials) section for the full
+precedence and per-provider env-var table. A missing key raises an actionable
+`aix.MissingCredentialError` naming which key to set and where to get one.
+
 ## Examples
 
 ### 01_simple_chat.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,30 @@ _aix_chat = sys.modules["aix.chat"]
 _aix_embeddings = sys.modules["aix.embeddings"]
 
 
+@pytest.fixture(autouse=True)
+def dummy_provider_keys(monkeypatch):
+    """Provide dummy provider API keys for the whole suite.
+
+    Credential preflight (``aix.credentials.requires_credentials``) now raises
+    ``MissingCredentialError`` when a key is genuinely absent. Existing tests mock
+    the LiteLLM call but run without real keys, so we inject placeholders here;
+    LiteLLM is mocked, so the dummy values are never used over the wire.
+
+    Credential-specific tests opt out by clearing the relevant env vars
+    (``monkeypatch.delenv``) and patching the config-store lookup. Video
+    providers (runway/pika) are deliberately excluded: test_video asserts on
+    their presence/absence, so the suite must not seed them globally.
+    """
+    from aix.credentials import PROVIDER_ENV_VARS, provider_env_vars
+
+    excluded = {"runway", "pika"}
+    for provider in PROVIDER_ENV_VARS:
+        if provider in excluded:
+            continue
+        for env_name in provider_env_vars(provider):
+            monkeypatch.setenv(env_name, "sk-test-dummy-key")
+
+
 @pytest.fixture
 def mock_litellm_completion():
     """Mock LiteLLM completion function."""

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,169 @@
+"""Tests for unified credential resolution (aix.credentials) and its wiring.
+
+Covers the resolution layers, provider inference, the actionable
+``MissingCredentialError``, the ``requires_credentials`` preflight decorator,
+the ``check_keys`` doctor, and end-to-end ``api_key=`` injection into the
+LiteLLM call from ``chat``.
+"""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aix.credentials import (
+    PROVIDER_ENV_VARS,
+    MissingCredentialError,
+    check_keys,
+    check_requirements,
+    infer_provider,
+    provider_env_vars,
+    requires_credentials,
+    resolve_api_key,
+)
+
+_aix_chat = sys.modules["aix.chat"]
+
+
+@pytest.fixture
+def no_keys(monkeypatch):
+    """Clear every known provider env var and make the config store look empty."""
+    for provider in PROVIDER_ENV_VARS:
+        for env_name in provider_env_vars(provider):
+            monkeypatch.delenv(env_name, raising=False)
+    # Don't let a real local config store (or a project .env) leak a key in.
+    monkeypatch.setattr("aix.credentials._lookup_store", lambda name: None)
+    monkeypatch.setattr("aix.credentials._dotenv_loaded", True)
+
+
+class TestProviderInference:
+    def test_infer_from_model(self):
+        assert infer_provider("gpt-4o") == "openai"
+        assert infer_provider("claude-sonnet-4-20250514") == "anthropic"
+
+    def test_provider_name_passthrough(self):
+        assert infer_provider("openrouter") == "openrouter"
+
+    def test_none(self):
+        assert infer_provider(None) is None
+
+    def test_env_var_aliases(self):
+        # gemini accepts both GEMINI_ and GOOGLE_ names.
+        assert provider_env_vars("gemini") == ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+        assert provider_env_vars("totally-unknown") == []
+
+
+class TestResolveApiKey:
+    def test_explicit_arg_wins(self, no_keys):
+        assert resolve_api_key("gpt-4o", api_key="sk-explicit") == "sk-explicit"
+
+    def test_env_var(self, no_keys, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        assert resolve_api_key("gpt-4o") == "sk-from-env"
+
+    def test_store_fallback(self, no_keys, monkeypatch):
+        monkeypatch.setattr(
+            "aix.credentials._lookup_store",
+            lambda name: "sk-from-store" if name == "OPENAI_API_KEY" else None,
+        )
+        assert resolve_api_key("gpt-4o") == "sk-from-store"
+
+    def test_env_beats_store(self, no_keys, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        monkeypatch.setattr("aix.credentials._lookup_store", lambda name: "sk-store")
+        assert resolve_api_key("gpt-4o") == "sk-from-env"
+
+    def test_missing_returns_none(self, no_keys):
+        assert resolve_api_key("gpt-4o") is None
+
+
+class TestCheckRequirements:
+    def test_passes_with_key(self, no_keys, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+        assert check_requirements("gpt-4o") is True
+
+    def test_raises_when_missing(self, no_keys):
+        with pytest.raises(MissingCredentialError) as exc:
+            check_requirements("gpt-4o")
+        msg = str(exc.value)
+        # Names which key, how to set it, and where to get one.
+        assert "OPENAI_API_KEY" in msg
+        assert "export" in msg
+        assert "platform.openai.com" in msg
+
+    def test_error_never_leaks_value(self, no_keys):
+        err = MissingCredentialError("gpt-4o")
+        assert "sk-" not in str(err)
+
+
+class TestRequiresCredentialsDecorator:
+    def test_runs_when_key_present(self, no_keys, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+
+        @requires_credentials(lambda: "gpt-4o")
+        def f(*, model=None, api_key=None):
+            return "ran"
+
+        assert f() == "ran"
+
+    def test_raises_when_missing(self, no_keys):
+        @requires_credentials(lambda: "gpt-4o")
+        def f(*, model=None, api_key=None):
+            return "ran"
+
+        with pytest.raises(MissingCredentialError):
+            f()
+
+    def test_explicit_api_key_satisfies_preflight(self, no_keys):
+        @requires_credentials(lambda: "gpt-4o")
+        def f(*, model=None, api_key=None):
+            return "ran"
+
+        assert f(api_key="sk-explicit") == "ran"
+
+
+class TestCheckKeys:
+    def test_reports_availability_without_values(self, no_keys, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+        report = check_keys(["openai", "anthropic"])
+        assert report["openai"]["available"] is True
+        assert report["openai"]["source"] == "env"
+        assert report["anthropic"]["available"] is False
+        # No key value anywhere in the report.
+        assert "sk-secret" not in repr(report)
+
+
+class TestChatKeyInjection:
+    """End-to-end: chat injects the resolved api_key into the LiteLLM call."""
+
+    @patch.object(_aix_chat, "_litellm_completion")
+    def test_explicit_api_key_injected(self, mock_completion, no_keys):
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = "ok"
+        mock_completion.return_value = mock_response
+
+        _aix_chat.chat("hi", model="gpt-4o", api_key="sk-explicit")
+
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-explicit"
+
+    @patch.object(_aix_chat, "_litellm_completion")
+    def test_env_api_key_injected(self, mock_completion, no_keys, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message = Mock()
+        mock_response.choices[0].message.content = "ok"
+        mock_completion.return_value = mock_response
+
+        _aix_chat.chat("hi", model="gpt-4o")
+
+        assert mock_completion.call_args[1]["api_key"] == "sk-from-env"
+
+    @patch.object(_aix_chat, "_litellm_completion")
+    def test_missing_key_raises_before_litellm(self, mock_completion, no_keys):
+        with pytest.raises(MissingCredentialError):
+            _aix_chat.chat("hi", model="gpt-4o")
+        mock_completion.assert_not_called()


### PR DESCRIPTION
Closes #24. Refs #22 (final piece of the config/credentials redesign).

## What

A single, documented credential-resolution path used by every key-requiring function, replacing the three inconsistent mechanisms (LiteLLM implicit env reading, the orphaned config2py getter, and raw `os.getenv`).

New `aix/credentials.py`:
- **`resolve_api_key(model_or_provider, *, api_key=None, prompt_if_missing=False)`** — layers, highest precedence first: explicit arg → provider env var (with soft `.env` discovery) → AIX config store (flat, keyed by canonical env-var name) → (REPL-only) prompt + persist. Returns `None` if genuinely absent.
- **`PROVIDER_ENV_VARS`** curated table + provider inference via `litellm.get_llm_provider`.
- **`MissingCredentialError`** — names *which* key is missing, *how* to set it, *where* to get one. Raised via the **`@requires_credentials`** decorator (presence-only preflight — no network), keeping error-raising out of business logic.
- **`check_keys()`** doctor — per-provider availability; key values are never logged or returned.

Wiring:
- Keyword-only `api_key=` added to `chat`, `embeddings`, `generate_image`/`generate_images`/`edit_image`/`create_variation`, `text_to_speech`, `transcribe`, `translate_audio`, and `generate_video`. Resolved key injected into the LiteLLM call (falls back to LiteLLM's own reading when `None`).
- Consolidated `video.get_available_providers`, `ai_models.sources.ProviderAPISource`, and `gen_ai/google_genai` onto `resolve_api_key`. No raw `os.getenv` key reads remain.
- Public API: `resolve_api_key`, `check_requirements`, `check_keys`, `MissingCredentialError`, `PROVIDER_ENV_VARS` exported from `aix`.
- README "Providing credentials" section + per-provider env-var table.

## Design decisions (confirmed with maintainer)
- **Soft `.env` discovery** — loaded only if `python-dotenv` is installed; no new hard dependency. Explicit env vars always win over `.env`.
- **Flat store keyed by env-var name** — store and env layer share one namespace.
- **Presence-only preflight** — no network validation on the hot path; that belongs (optionally) in `check_keys`.

## Tests
- New `tests/test_credentials.py`: provider inference, resolution layers + precedence, `MissingCredentialError` content + redaction, the decorator, `check_keys`, and end-to-end `api_key=` injection into the (mocked) LiteLLM call.
- `conftest.py` gains an autouse fixture seeding dummy provider keys so existing mocked-LiteLLM tests keep passing now that preflight is active (video providers excluded — `test_video` asserts on their presence/absence).
- Full suite: **180 passed, 1 skipped**; doctests green; black clean.

## Acceptance criteria
- [x] All functions resolve keys through one documented path (arg → env/.env → store → REPL prompt).
- [x] `api_key=` accepted (keyword-only) on every key-requiring function.
- [x] Missing-key failures raise `MissingCredentialError` with which/how/where.
- [x] `aix.check_keys()` reports availability per provider.
- [x] No raw `os.getenv` key reads remain; the orphaned `get_config` path is unified.
- [x] README "Providing credentials" section with precedence + env-var table.