### PR TITLE
prompt_func: add egress + name (oa.prompt_function parity)

### DIFF
--- a/aix/prompts.py
+++ b/aix/prompts.py
@@ -178,8 +178,10 @@ def prompt_func(
     template: str,
     *,
     output_schema: Union[dict, type] = None,
+    egress: Callable[[Any], Any] = None,
     model: str = None,
     temperature: float = None,
+    name: str = None,
     **chat_kwargs,
 ) -> Callable:
     """Create a callable function from a prompt template.
@@ -189,6 +191,7 @@ def prompt_func(
 
     Without output_schema: Returns text
     With output_schema: Returns structured data (dict, list, etc.)
+    With egress: Returns whatever the egress post-processor returns.
 
     Args:
         template: Prompt template with {var} placeholders for parameters
@@ -196,8 +199,15 @@ def prompt_func(
             - Dict mapping field names to types: {"name": str, "age": int}
             - A single type for simple outputs: str, int, list, etc.
             - None for plain text output (default)
+        egress: Optional post-processor ``(result) -> Any`` applied to the output
+            before returning — on both the text and structured paths. Lets a caller
+            keep "prompt → typed Python value" inside the facade (e.g. parse the
+            LLM text into a list of lines/ids) instead of wrapping the returned
+            function. ``None`` (default) returns the raw result unchanged.
         model: Model to use for this function
         temperature: Temperature for generation
+        name: Optional ``__name__`` for the generated function (for tracing /
+            identity). Defaults to ``"prompt_based_function"``.
         **chat_kwargs: Additional parameters passed to chat()
 
     Returns:
@@ -271,16 +281,17 @@ def prompt_func(
                 temperature=temperature or 0.0,  # Lower temp for structured output
                 **chat_kwargs,
             )
-            return _parse_structured_output(response, json_schema)
+            result = _parse_structured_output(response, json_schema)
         else:
             # Plain text output
-            response = chat(
+            result = chat(
                 formatted_prompt, model=model, temperature=temperature, **chat_kwargs
             )
-            return response
+        # Optional post-processing (e.g. parse text into a list of ids/lines).
+        return egress(result) if egress is not None else result
 
     # Set function name and docstring
-    generated_function.__name__ = "prompt_based_function"
+    generated_function.__name__ = name or "prompt_based_function"
     generated_function.__doc__ = (
         f"Auto-generated function from prompt template.\n\n"
         f"Template: {template}\n\n"
@@ -299,6 +310,7 @@ def prompt_func(
     # Add metadata
     generated_function.template = template
     generated_function.output_schema = output_schema
+    generated_function.egress = egress
     generated_function.param_names = param_names
 
     return generated_function

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -171,6 +171,55 @@ class TestPromptFunc:
         assert func.param_names == ["param"]
 
 
+class TestEgressAndName:
+    """Tests for the egress post-processor and name parameters."""
+
+    @patch("aix.prompts.chat")
+    def test_egress_postprocesses_text_output(self, mock_chat):
+        """egress transforms the plain-text result before returning."""
+        mock_chat.return_value = "a\nb\nc"
+        func = prompt_func("List about {topic}", egress=lambda s: s.splitlines())
+        assert func(topic="x") == ["a", "b", "c"]
+
+    @patch("aix.prompts.chat")
+    def test_no_egress_returns_raw_text(self, mock_chat):
+        """Without egress the raw string is returned unchanged (back-compat)."""
+        mock_chat.return_value = "hello"
+        func = prompt_func("Say {x}")
+        assert func(x="hi") == "hello"
+
+    @patch("aix.prompts.chat")
+    def test_egress_applies_to_structured_output(self, mock_chat):
+        """egress also runs on the parsed structured-output path."""
+        mock_chat.return_value = '{"name": "Alice", "age": 30}'
+        func = prompt_func(
+            "Extract {text}",
+            output_schema={"name": str, "age": int},
+            egress=lambda d: d["name"],
+        )
+        assert func(text="...") == "Alice"
+
+    @patch("aix.prompts.chat")
+    def test_name_sets_function_dunder_name(self, mock_chat):
+        """name overrides the generated function's __name__."""
+        mock_chat.return_value = "x"
+        func = prompt_func("Do {x}", name="select_capabilities")
+        assert func.__name__ == "select_capabilities"
+
+    @patch("aix.prompts.chat")
+    def test_default_name_is_unchanged(self, mock_chat):
+        """Omitting name keeps the historical default."""
+        func = prompt_func("Do {x}")
+        assert func.__name__ == "prompt_based_function"
+
+    @patch("aix.prompts.chat")
+    def test_egress_exposed_as_metadata(self, mock_chat):
+        """The egress is introspectable on the returned function."""
+        eg = lambda s: s
+        func = prompt_func("Do {x}", egress=eg)
+        assert func.egress is eg
+
+
 class TestPromptToText:
     """Tests for prompt_to_text convenience function."""
 


### PR DESCRIPTION
Adds `egress` (output post-processor) and `name` to `prompt_func` — back-compatible, defaults unchanged. This is the missing facade piece for migrating downstream packages off `oa` onto `aix` (first consumer: `ir`, see i2mint/ir#59).

- `egress(result) -> Any` applied on both the text and structured paths.
- `name` sets the generated function's `__name__`.
- 6 new tests; full suite green (180).

Closes #29.