### PR TITLE
feat(vision): image→text (describe_image) over LiteLLM

### DIFF
--- a/aix/__init__.py
+++ b/aix/__init__.py
@@ -122,6 +122,10 @@ from aix.video import (
     GeneratedVideo,
     get_available_providers as get_video_providers,
 )
+from aix.vision import (
+    describe_image,
+    to_image_content,
+)
 
 # Legacy interfaces (for backward compatibility)
 from aix.gen_ai import chat_models, chat_funcs
@@ -194,6 +198,9 @@ __all__ = [
     "extend_video",
     "GeneratedVideo",
     "get_video_providers",
+    # Vision (image -> text)
+    "describe_image",
+    "to_image_content",
     # Legacy
     "chat_models",
     "chat_funcs",

--- a/aix/config.py
+++ b/aix/config.py
@@ -54,6 +54,9 @@ Examples:
         tts_voice = "alloy"
         transcription_model = "whisper-1"
 
+        [vision]
+        model = "gpt-4o-mini"
+
         [aliases]
         fast = "openai/gpt-4o-mini"
         best = "anthropic/claude-sonnet-4"
@@ -79,6 +82,7 @@ __all__ = [
     "ImageConfig",
     "AudioConfig",
     "VideoConfig",
+    "VisionConfig",
     "AixConfig",
     "load_config",
     "get_config",
@@ -164,6 +168,19 @@ class VideoConfig:
     provider: Optional[str] = _opt(None, flat="video_provider")
 
 
+@dataclass(frozen=True)
+class VisionConfig:
+    """Defaults for ``describe_image`` (image→text).
+
+    The default is a cheap, vision-capable OpenAI model so it works with the
+    same ``OPENAI_API_KEY`` most users already have; override per call
+    (``describe_image(..., model=...)``), via ``configure(vision_model=...)``,
+    or the ``[vision]`` TOML section to route to Claude / Gemini / etc.
+    """
+
+    model: str = _opt("gpt-4o-mini", flat="vision_model")
+
+
 # Maps the AixConfig attribute name -> (sub-config class, TOML section name).
 # The attribute name doubles as the TOML section name.
 _SECTIONS = {
@@ -172,6 +189,7 @@ _SECTIONS = {
     "image": ImageConfig,
     "audio": AudioConfig,
     "video": VideoConfig,
+    "vision": VisionConfig,
 }
 
 
@@ -184,6 +202,7 @@ class AixConfig:
     image: ImageConfig = field(default_factory=ImageConfig)
     audio: AudioConfig = field(default_factory=AudioConfig)
     video: VideoConfig = field(default_factory=VideoConfig)
+    vision: VisionConfig = field(default_factory=VisionConfig)
     aliases: Mapping[str, str] = field(default_factory=lambda: dict(DEFAULT_ALIASES))
 
 

--- a/aix/vision.py
+++ b/aix/vision.py
@@ -1,0 +1,247 @@
+"""Image-to-text (vision) interface for AIX.
+
+The cross-modal counterpart to :mod:`aix.image` (which is text→image): given an
+image, produce text — a caption, an answer to a question about it, or a
+structured judgement. Like the rest of AIX it is a thin, provider-neutral facade
+over LiteLLM's multimodal ``completion`` (the same backend ``chat`` uses), so the
+same call routes to any vision-capable provider (OpenAI, Anthropic, Gemini,
+OpenRouter, …) by model id alone.
+
+:func:`describe_image` is the primitive: image (URL / local path / bytes / PIL
+image / ``data:`` URI) + a prompt → text. :func:`to_image_content` exposes the
+multimodal content block builder so callers can assemble richer messages (e.g.
+multiple images in one turn) and pass them straight to :func:`aix.chat`.
+
+Examples:
+    Caption an image (any vision-capable model):
+
+    >>> from aix.vision import describe_image
+    >>> describe_image("https://example.com/cat.jpg")  # doctest: +SKIP
+    'A grey tabby cat sitting on a windowsill in afternoon light.'
+
+    Ask a specific question:
+
+    >>> describe_image("photo.png", prompt="What colour is the car?")  # doctest: +SKIP
+    'The car is red.'
+
+    Build a multi-image message yourself and hand it to ``chat``:
+
+    >>> from aix import chat
+    >>> from aix.vision import to_image_content
+    >>> msg = [{"role": "user", "content": [          # doctest: +SKIP
+    ...     {"type": "text", "text": "Which is brighter?"},
+    ...     to_image_content("a.jpg"), to_image_content("b.jpg"),
+    ... ]}]
+    >>> chat(msg, model="gpt-4o")  # doctest: +SKIP
+    'The second image is brighter.'
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Any, Union
+
+from aix.config import (
+    get_config as _get_config,
+    resolve_model as _resolve_model,
+    VisionConfig as _VisionConfig,
+)
+from aix.credentials import (
+    resolve_api_key as _resolve_api_key,
+    requires_credentials as _requires_credentials,
+)
+
+# LiteLLM is a soft dependency, imported privately (mirrors aix.chat).
+try:
+    from litellm import completion as _litellm_completion
+except ImportError:  # pragma: no cover - exercised only without litellm
+    _litellm_completion = None
+
+__all__ = [
+    "describe_image",
+    "to_image_content",
+    "DFLT_VISION_MODEL",
+    "DFLT_VISION_PROMPT",
+]
+
+#: Shipped-default vision model, kept for reference. The *active* default is
+#: resolved from ``aix.config`` at call time (see :class:`aix.config.VisionConfig`).
+DFLT_VISION_MODEL = _VisionConfig().model
+
+#: Default instruction when the caller doesn't supply one.
+DFLT_VISION_PROMPT = "Describe this image in detail."
+
+#: Default JPEG when raw bytes can't be sniffed (most stock images are JPEG).
+_DFLT_IMAGE_MIME = "image/jpeg"
+
+#: Magic-number prefixes for sniffing a MIME type from raw bytes.
+_MAGIC_MIME = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"RIFF", "image/webp"),  # RIFF....WEBP; prefix is enough to distinguish here
+    (b"BM", "image/bmp"),
+)
+
+
+def to_image_content(
+    image: "Union[str, Path, bytes, Any]", *, detail: "str | None" = None
+) -> dict:
+    """Build a multimodal ``image_url`` content block for ``image``.
+
+    ``image`` may be:
+
+    - an ``http(s)://`` URL or a ``data:`` URI — passed through verbatim;
+    - a local file path (``str`` or :class:`~pathlib.Path`) — read and inlined
+      as a base64 ``data:`` URI with a guessed MIME type;
+    - raw ``bytes`` — base64-inlined (MIME sniffed from magic bytes, else JPEG);
+    - a PIL ``Image`` — encoded to PNG and inlined.
+
+    ``detail`` (``"low"`` | ``"high"`` | ``"auto"``) is forwarded when set; the
+    block is the OpenAI/LiteLLM multimodal shape understood across providers.
+
+    >>> to_image_content("https://x/y.jpg")
+    {'type': 'image_url', 'image_url': {'url': 'https://x/y.jpg'}}
+    >>> to_image_content("data:image/png;base64,AAAA")["image_url"]["url"][:10]
+    'data:image'
+    """
+    url = _to_image_url(image)
+    image_url: dict[str, Any] = {"url": url}
+    if detail is not None:
+        image_url["detail"] = detail
+    return {"type": "image_url", "image_url": image_url}
+
+
+@_requires_credentials(lambda: _get_config().vision.model)
+def describe_image(
+    image: "Union[str, Path, bytes, Any]",
+    *,
+    prompt: str = DFLT_VISION_PROMPT,
+    model: "str | None" = None,
+    api_key: "str | None" = None,
+    max_tokens: "int | None" = None,
+    temperature: "float | None" = None,
+    detail: "str | None" = None,
+    **kwargs: Any,
+) -> str:
+    """Describe (or answer a question about) ``image`` and return the text.
+
+    The image→text primitive. ``image`` accepts a URL, a local path, raw bytes,
+    a PIL image, or a ``data:`` URI (see :func:`to_image_content`). ``prompt`` is
+    the instruction (default: a generic "describe this image"); pass a question
+    for VQA or a rubric for a judgement. Everything past ``image`` is keyword.
+
+    Args:
+        image: The image (URL / path / bytes / PIL image / ``data:`` URI).
+        prompt: The text instruction accompanying the image.
+        model: Vision-capable model id (e.g. ``gpt-4o``, ``claude-sonnet-4-6``,
+            ``gemini/gemini-1.5-pro``) or an alias. ``None`` → the configured
+            default (:class:`aix.config.VisionConfig`).
+        api_key: Explicit API key; ``None`` resolves it from the environment /
+            ``.env`` / config store for the model's provider.
+        max_tokens: Cap on generated tokens (``None`` → provider default).
+        temperature: Sampling temperature (``None`` → provider default).
+        detail: Image detail hint (``"low"`` | ``"high"`` | ``"auto"``).
+        **kwargs: Extra provider-specific params forwarded to LiteLLM.
+
+    Returns:
+        The model's text response.
+
+    Raises:
+        ImportError: If LiteLLM is not installed.
+
+    >>> describe_image("cat.jpg", prompt="Caption it.")  # doctest: +SKIP
+    'A cat on a sofa.'
+    """
+    if _litellm_completion is None:
+        raise ImportError(
+            "LiteLLM is required for vision functionality. "
+            "Install it with: pip install litellm"
+        )
+
+    cfg = _get_config().vision
+    model = _resolve_model(model or cfg.model)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                to_image_content(image, detail=detail),
+            ],
+        }
+    ]
+
+    litellm_kwargs: dict[str, Any] = {"model": model, "messages": messages}
+    if max_tokens is not None:
+        litellm_kwargs["max_tokens"] = max_tokens
+    if temperature is not None:
+        litellm_kwargs["temperature"] = temperature
+
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        litellm_kwargs["api_key"] = resolved_key
+
+    litellm_kwargs.update(kwargs)
+
+    response = _litellm_completion(**litellm_kwargs)
+    return _extract_text(response)
+
+
+# --- internals --------------------------------------------------------------
+
+
+def _to_image_url(image: "Union[str, Path, bytes, Any]") -> str:
+    """Resolve ``image`` to a URL or base64 ``data:`` URI for a content block."""
+    if isinstance(image, Path):
+        return _data_uri(*_read_path(image))
+    if isinstance(image, bytes):
+        return _data_uri(image, _sniff_mime(image))
+    if isinstance(image, str):
+        if image.startswith(("http://", "https://", "data:")):
+            return image
+        return _data_uri(*_read_path(Path(image)))
+    # Treat anything else as a PIL image (duck-typed: has .save).
+    if hasattr(image, "save"):
+        return _data_uri(_pil_to_png_bytes(image), "image/png")
+    raise TypeError(
+        f"Unsupported image type {type(image)!r}; pass a URL, path, bytes, "
+        "PIL image, or data: URI."
+    )
+
+
+def _read_path(path: Path) -> "tuple[bytes, str]":
+    data = path.read_bytes()
+    mime = mimetypes.guess_type(str(path))[0] or _sniff_mime(data)
+    return data, mime
+
+
+def _sniff_mime(data: bytes) -> str:
+    for prefix, mime in _MAGIC_MIME:
+        if data.startswith(prefix):
+            return mime
+    return _DFLT_IMAGE_MIME
+
+
+def _data_uri(data: bytes, mime: str) -> str:
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{b64}"
+
+
+def _pil_to_png_bytes(image: Any) -> bytes:
+    import io
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _extract_text(response: Any) -> str:
+    """Pull text out of a LiteLLM response (mirrors aix.chat)."""
+    try:
+        return response.choices[0].message.content or ""
+    except (AttributeError, IndexError, KeyError):  # pragma: no cover - defensive
+        return str(response)

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,122 @@
+"""Tests for aix.vision module (offline — LiteLLM is mocked, no API calls)."""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aix.vision import describe_image, to_image_content
+
+# `aix.vision` may resolve to the exported function name on some builds; patch
+# the submodule object directly (same robustness trick as test_chat.py).
+import aix.vision  # noqa: F401
+
+_aix_vision = sys.modules["aix.vision"]
+
+
+def _mock_response(text="A description."):
+    response = Mock()
+    response.choices = [Mock()]
+    response.choices[0].message = Mock()
+    response.choices[0].message.content = text
+    return response
+
+
+class TestToImageContent:
+    """The multimodal content-block builder."""
+
+    def test_http_url_passthrough(self):
+        block = to_image_content("https://example.com/a.jpg")
+        assert block == {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/a.jpg"},
+        }
+
+    def test_data_uri_passthrough(self):
+        uri = "data:image/png;base64,AAAA"
+        assert to_image_content(uri)["image_url"]["url"] == uri
+
+    def test_bytes_to_data_uri_sniffs_png(self):
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+        url = to_image_content(png)["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
+    def test_bytes_default_mime_when_unknown(self):
+        url = to_image_content(b"not-a-known-magic")["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,")
+
+    def test_path_to_data_uri(self, tmp_path):
+        p = tmp_path / "x.png"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        url = to_image_content(str(p))["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
+    def test_detail_forwarded(self):
+        block = to_image_content("https://x/y.jpg", detail="low")
+        assert block["image_url"]["detail"] == "low"
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError):
+            to_image_content(12345)
+
+
+class TestDescribeImage:
+    """The image->text primitive."""
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_url_builds_multimodal_message(self, mock_completion):
+        mock_completion.return_value = _mock_response("A grey cat.")
+
+        result = describe_image("https://example.com/cat.jpg", model="gpt-4o")
+
+        assert result == "A grey cat."
+        mock_completion.assert_called_once()
+        kwargs = mock_completion.call_args[1]
+        content = kwargs["messages"][0]["content"]
+        # text block first, then the image_url block
+        assert content[0] == {"type": "text", "text": "Describe this image in detail."}
+        assert content[1]["type"] == "image_url"
+        assert content[1]["image_url"]["url"] == "https://example.com/cat.jpg"
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_custom_prompt(self, mock_completion):
+        mock_completion.return_value = _mock_response("Red.")
+
+        describe_image("https://x/car.jpg", prompt="What colour?", model="gpt-4o")
+
+        content = mock_completion.call_args[1]["messages"][0]["content"]
+        assert content[0]["text"] == "What colour?"
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_max_tokens_and_temperature_threaded(self, mock_completion):
+        mock_completion.return_value = _mock_response()
+
+        describe_image(
+            "https://x/a.jpg", model="gpt-4o", max_tokens=64, temperature=0.0
+        )
+
+        kwargs = mock_completion.call_args[1]
+        assert kwargs["max_tokens"] == 64
+        assert kwargs["temperature"] == 0.0
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_detail_threaded_into_image_block(self, mock_completion):
+        mock_completion.return_value = _mock_response()
+
+        describe_image("https://x/a.jpg", model="gpt-4o", detail="high")
+
+        block = mock_completion.call_args[1]["messages"][0]["content"][1]
+        assert block["image_url"]["detail"] == "high"
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_extra_kwargs_forwarded(self, mock_completion):
+        mock_completion.return_value = _mock_response()
+
+        describe_image("https://x/a.jpg", model="gpt-4o", top_p=0.5)
+
+        assert mock_completion.call_args[1]["top_p"] == 0.5
+
+    def test_missing_litellm_raises_importerror(self):
+        with patch.object(_aix_vision, "_litellm_completion", None):
+            with pytest.raises(ImportError, match="LiteLLM is required"):
+                describe_image("https://x/a.jpg", model="gpt-4o")


### PR DESCRIPTION
## image→text (vision) for aix

Adds the cross-modal counterpart to `aix.image` (text→image): given an image, produce text.

- **`aix.describe_image(image, *, prompt, model, api_key, max_tokens, temperature, detail, **kwargs) -> str`** — caption / VQA / vision judgement. `image` accepts a URL, local path, `bytes`, a PIL image, or a `data:` URI. Routes through LiteLLM's multimodal `completion` (the same backend `aix.chat` uses), so any vision-capable provider (OpenAI, Anthropic, Gemini, OpenRouter, …) works by model id alone — **provider-neutral, no Anthropic-SDK coupling**.
- **`aix.to_image_content(image, *, detail=None) -> dict`** — the multimodal content-block builder, so callers can assemble richer multi-image messages and hand them to `aix.chat`.
- **`VisionConfig`** — default vision model (`gpt-4o-mini`, a cheap vision-capable OpenAI default consistent with aix's other defaults), overridable via `AIX_VISION_MODEL` / `[vision]` TOML / `configure(vision_model=…)`.

Mirrors the existing `chat.py`/`image.py` conventions (lazy litellm import, `@requires_credentials`, `resolve_model`, model aliasing).

### Why
This is the "studied image→text gap" called out by the `illustration` package's design — its Layer-2 agentic curation (the bounded CRAG loop) needs image captioning + VLM judging, and per the federation policy the capability belongs in `aix`, not inlined in the consumer. `illustration`'s `[curate]` extra depends on this.

### Tests
New `tests/test_vision.py` — fully offline (LiteLLM mocked), covers the content-block builder (URL/data-URI/bytes/path/detail), the multimodal message shape, kwarg threading, and the missing-LiteLLM path. Full suite: **198 passing**.

Purely additive — no breaking changes.
