### PR TITLE
Add compare_images — structured vision likeness check

### DIFF
--- a/aix/__init__.py
+++ b/aix/__init__.py
@@ -125,6 +125,9 @@ from aix.video import (
 from aix.vision import (
     describe_image,
     to_image_content,
+    compare_images,
+    RubricVerdict,
+    ImageComparison,
 )
 
 # Legacy interfaces (for backward compatibility)
@@ -201,6 +204,9 @@ __all__ = [
     # Vision (image -> text)
     "describe_image",
     "to_image_content",
+    "compare_images",
+    "RubricVerdict",
+    "ImageComparison",
     # Legacy
     "chat_models",
     "chat_funcs",

--- a/aix/vision.py
+++ b/aix/vision.py
@@ -34,14 +34,28 @@ Examples:
     ... ]}]
     >>> chat(msg, model="gpt-4o")  # doctest: +SKIP
     'The second image is brighter.'
+
+:func:`compare_images` builds on these primitives: it puts a *candidate* image
+beside one or more *reference* images and asks a vision model, via a structured
+JSON path, for an explainable per-aspect likeness verdict — the "explain the
+drift" half of a reference supervisor (face / costume / setting / lighting /
+props matched?). The numeric identity-cosine gate lives elsewhere (lookbook);
+this layer is the explainable checklist on top of it.
+
+    >>> from aix.vision import compare_images
+    >>> verdict = compare_images("gen.png", "locked_ref.png")  # doctest: +SKIP
+    >>> verdict.match, verdict["identity"].match  # doctest: +SKIP
+    (True, True)
 """
 
 from __future__ import annotations
 
 import base64
+import json
 import mimetypes
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Sequence, Union
 
 from aix.config import (
     get_config as _get_config,
@@ -62,8 +76,13 @@ except ImportError:  # pragma: no cover - exercised only without litellm
 __all__ = [
     "describe_image",
     "to_image_content",
+    "compare_images",
+    "RubricVerdict",
+    "ImageComparison",
     "DFLT_VISION_MODEL",
     "DFLT_VISION_PROMPT",
+    "DFLT_COMPARE_RUBRIC",
+    "DFLT_FILM_RUBRIC",
 ]
 
 #: Shipped-default vision model, kept for reference. The *active* default is
@@ -72,6 +91,22 @@ DFLT_VISION_MODEL = _VisionConfig().model
 
 #: Default instruction when the caller doesn't supply one.
 DFLT_VISION_PROMPT = "Describe this image in detail."
+
+#: Default rubric for :func:`compare_images` — a generic likeness checklist.
+#: Each entry is one aspect the vision model judges independently.
+DFLT_COMPARE_RUBRIC = ("identity", "costume", "setting", "lighting", "props")
+
+#: Filmmaking-oriented rubric (Noel's reference-supervisor checklist): the
+#: locked face, the architecture/set, the lighting, and the props. Pass it as
+#: ``rubric=`` when comparing a generated frame against a locked reference.
+DFLT_FILM_RUBRIC = (
+    "face_identity",
+    "costume",
+    "setting_architecture",
+    "lighting",
+    "props",
+    "skin_realism",
+)
 
 #: Default JPEG when raw bytes can't be sniffed (most stock images are JPEG).
 _DFLT_IMAGE_MIME = "image/jpeg"
@@ -191,7 +226,352 @@ def describe_image(
     return _extract_text(response)
 
 
+# --- compare_images: structured two-image likeness check --------------------
+
+
+@dataclass(frozen=True)
+class RubricVerdict:
+    """A vision model's verdict on a single rubric aspect.
+
+    Attributes:
+        aspect: The rubric item this verdict is about (e.g. ``"identity"``).
+        match: Whether the candidate matches the reference for this aspect.
+        confidence: The model's self-reported confidence in ``[0.0, 1.0]``.
+        note: A short free-text explanation of the verdict.
+    """
+
+    aspect: str
+    match: bool
+    confidence: float
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class ImageComparison:
+    """Structured result of comparing a candidate image to reference(s).
+
+    Behaves like an ordered, read-only mapping of ``aspect -> RubricVerdict``
+    (``comparison["identity"]``, ``in``, iteration, ``len``) so per-aspect
+    lookups read naturally, while also carrying the overall verdict.
+
+    Attributes:
+        match: Overall pass/fail across the whole rubric.
+        confidence: Overall confidence in ``[0.0, 1.0]``.
+        explanation: A short overall summary of the comparison.
+        aspects: The per-aspect verdicts, one :class:`RubricVerdict` per
+            rubric item, in rubric order.
+        model: The vision model id that produced the verdict.
+    """
+
+    match: bool
+    confidence: float
+    explanation: str
+    aspects: tuple[RubricVerdict, ...] = field(default_factory=tuple)
+    model: "str | None" = None
+
+    def _by_aspect(self) -> "dict[str, RubricVerdict]":
+        return {verdict.aspect: verdict for verdict in self.aspects}
+
+    def __getitem__(self, aspect: str) -> RubricVerdict:
+        return self._by_aspect()[aspect]
+
+    def __contains__(self, aspect: object) -> bool:
+        return aspect in self._by_aspect()
+
+    def __iter__(self):
+        return iter(self._by_aspect())
+
+    def __len__(self) -> int:
+        return len(self.aspects)
+
+    def get(
+        self, aspect: str, default: "RubricVerdict | None" = None
+    ) -> "RubricVerdict | None":
+        """Return the verdict for ``aspect``, or ``default`` if absent."""
+        return self._by_aspect().get(aspect, default)
+
+
+#: Instruction prefix for the comparison prompt. Kept here (not inlined) so the
+#: phrasing is a single, tunable source of truth.
+_COMPARE_INSTRUCTION = (
+    "You are a strict visual continuity supervisor. The FIRST image is the "
+    "CANDIDATE; the remaining image(s) are the locked REFERENCE the candidate "
+    "must match. Judge each rubric aspect INDEPENDENTLY (do not let one aspect "
+    "color another). For each aspect decide whether the candidate matches the "
+    "reference, give a confidence in [0.0, 1.0], and a short note explaining "
+    "what matches or drifts. Then give an overall match (true only if every "
+    "important aspect matches), an overall confidence, and a one-sentence "
+    "explanation."
+)
+
+
+@_requires_credentials(lambda: _get_config().vision.model)
+def compare_images(
+    candidate: "Union[str, Path, bytes, Any]",
+    reference: "Union[str, Path, bytes, Any, Sequence[Any]]",
+    *,
+    rubric: "Sequence[str]" = DFLT_COMPARE_RUBRIC,
+    model: "str | None" = None,
+    api_key: "str | None" = None,
+    max_tokens: "int | None" = None,
+    temperature: "float | None" = 0.0,
+    detail: "str | None" = None,
+    instruction: str = _COMPARE_INSTRUCTION,
+    **kwargs: Any,
+) -> ImageComparison:
+    """Compare a ``candidate`` image to ``reference`` image(s) on a rubric.
+
+    The explainable half of a reference supervisor: a vision model returns a
+    per-aspect pass/fail checklist (does the face match? the costume? the set?
+    the lighting? the props?) plus an overall verdict — the explainable layer
+    over a cheap numeric identity-cosine gate (which lives elsewhere, e.g.
+    lookbook). Built on :func:`to_image_content` (multi-image content block)
+    and the same multimodal ``completion`` path as :func:`describe_image`,
+    asked via a JSON contract for a structured answer.
+
+    The comparison is *pointwise* (each aspect judged on its own), not a ranked
+    pairwise comparison, to avoid position bias.
+
+    Args:
+        candidate: The image under review (URL / path / bytes / PIL image /
+            ``data:`` URI — anything :func:`to_image_content` accepts).
+        reference: The locked reference — a single image *or* a sequence of
+            images (a locked set) in the same flexible formats. An empty
+            sequence is an error.
+        rubric: The aspects to evaluate, one verdict per item. Defaults to
+            :data:`DFLT_COMPARE_RUBRIC`; pass :data:`DFLT_FILM_RUBRIC` (or any
+            custom sequence) to override — e.g. ``("face", "architecture",
+            "props", "lighting")``. Must be non-empty.
+        model: Vision-capable model id or alias. ``None`` → the configured
+            default (:class:`aix.config.VisionConfig`).
+        api_key: Explicit API key; ``None`` resolves it for the model's
+            provider from the environment / ``.env`` / config store.
+        max_tokens: Cap on generated tokens (``None`` → provider default).
+        temperature: Sampling temperature (default ``0.0`` for a stable,
+            reproducible verdict; ``None`` → provider default).
+        detail: Image detail hint (``"low"`` | ``"high"`` | ``"auto"``),
+            applied to every image block.
+        instruction: The system-style framing prepended to the rubric. Has a
+            sensible default; override to retune the supervisor's strictness.
+        **kwargs: Extra provider-specific params forwarded to LiteLLM.
+
+    Returns:
+        An :class:`ImageComparison` — overall ``match`` / ``confidence`` /
+        ``explanation`` plus an ordered, mapping-like collection of
+        :class:`RubricVerdict` (one per rubric aspect, keyed by aspect).
+
+    Raises:
+        ImportError: If LiteLLM is not installed.
+        ValueError: If ``rubric`` is empty or ``reference`` is an empty
+            sequence, or if the model's reply can't be parsed as the expected
+            JSON verdict.
+
+    Examples:
+        Default rubric, single reference:
+
+        >>> compare_images("gen.png", "ref.png")  # doctest: +SKIP
+        ImageComparison(match=True, confidence=0.9, ...)
+
+        Filmmaking rubric, a locked reference *set*:
+
+        >>> from aix.vision import DFLT_FILM_RUBRIC
+        >>> compare_images(  # doctest: +SKIP
+        ...     candidate="frame_042.png",
+        ...     reference=["ref_front.png", "ref_side.png"],
+        ...     rubric=DFLT_FILM_RUBRIC,
+        ... )["face_identity"].match
+        True
+    """
+    # Validate arguments before checking the optional dependency, so a bad call
+    # (empty rubric / empty reference set) is reported the same way regardless of
+    # whether LiteLLM happens to be installed.
+    rubric = tuple(rubric)
+    if not rubric:
+        raise ValueError("`rubric` must contain at least one aspect to evaluate.")
+
+    references = _as_image_sequence(reference)
+    if not references:
+        raise ValueError(
+            "`reference` must be at least one image (got an empty sequence)."
+        )
+
+    if _litellm_completion is None:
+        raise ImportError(
+            "LiteLLM is required for vision functionality. "
+            "Install it with: pip install litellm"
+        )
+
+    cfg = _get_config().vision
+    model = _resolve_model(model or cfg.model)
+
+    text_block = {"type": "text", "text": _compare_prompt(instruction, rubric)}
+    image_blocks = [to_image_content(candidate, detail=detail)] + [
+        to_image_content(ref, detail=detail) for ref in references
+    ]
+    messages = [{"role": "user", "content": [text_block, *image_blocks]}]
+
+    litellm_kwargs: dict[str, Any] = {"model": model, "messages": messages}
+    if max_tokens is not None:
+        litellm_kwargs["max_tokens"] = max_tokens
+    if temperature is not None:
+        litellm_kwargs["temperature"] = temperature
+
+    resolved_key = _resolve_api_key(model, api_key=api_key)
+    if resolved_key is not None:
+        litellm_kwargs["api_key"] = resolved_key
+
+    litellm_kwargs.update(kwargs)
+
+    response = _litellm_completion(**litellm_kwargs)
+    raw = _extract_text(response)
+    return _parse_comparison(raw, rubric=rubric, model=model)
+
+
 # --- internals --------------------------------------------------------------
+
+
+def _as_image_sequence(reference: Any) -> "list[Any]":
+    """Normalise ``reference`` to a list of image inputs.
+
+    A single image (URL str / path / bytes / PIL image / ``data:`` URI) becomes
+    a one-element list; a non-string, non-bytes sequence is taken as a locked
+    set and returned as a list. ``str`` and ``bytes`` are *atomic* images here,
+    never iterated character/byte-wise.
+    """
+    if isinstance(reference, (str, bytes, Path)):
+        return [reference]
+    if hasattr(reference, "save"):  # a PIL image is iterable-ish; treat as atomic
+        return [reference]
+    if isinstance(reference, Sequence):
+        return list(reference)
+    # Any other iterable (generator, tuple already handled by Sequence) — be lenient.
+    try:
+        return list(reference)
+    except TypeError:
+        return [reference]
+
+
+def _compare_prompt(instruction: str, rubric: "tuple[str, ...]") -> str:
+    """Build the JSON-contract prompt asking for a per-aspect verdict."""
+    aspect_list = ", ".join(rubric)
+    schema = {
+        "match": "boolean — overall match across the whole rubric",
+        "confidence": "number in [0.0, 1.0] — overall confidence",
+        "explanation": "string — one-sentence overall summary",
+        "aspects": [
+            {
+                "aspect": "string — one of the rubric aspects, verbatim",
+                "match": "boolean",
+                "confidence": "number in [0.0, 1.0]",
+                "note": "string — short explanation",
+            }
+        ],
+    }
+    return (
+        f"{instruction}\n\n"
+        f"Rubric aspects to evaluate (one verdict each, use these exact names): "
+        f"{aspect_list}.\n\n"
+        f"Respond with ONLY valid JSON of this shape (no prose, no code fence):\n"
+        f"{json.dumps(schema)}\n"
+        f"Include exactly one entry in \"aspects\" for each rubric aspect above."
+    )
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "1", "match", "pass"}
+    return bool(value)
+
+
+def _coerce_confidence(value: Any) -> float:
+    try:
+        conf = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, conf))
+
+
+def _parse_comparison(
+    raw: str, *, rubric: "tuple[str, ...]", model: "str | None"
+) -> ImageComparison:
+    """Parse the model's JSON reply into an :class:`ImageComparison`.
+
+    Tolerant of a markdown code fence around the JSON; raises ``ValueError`` if
+    no JSON object can be recovered. Missing aspects are filled with a
+    low-confidence non-match so the result always covers the full rubric.
+    """
+    data = _loads_lenient(raw)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Expected a JSON object verdict from the model, got: {raw[:120]!r}"
+        )
+
+    by_aspect: dict[str, RubricVerdict] = {}
+    for item in data.get("aspects", []) or []:
+        if not isinstance(item, dict):
+            continue
+        aspect = str(item.get("aspect", "")).strip()
+        if not aspect:
+            continue
+        by_aspect[aspect] = RubricVerdict(
+            aspect=aspect,
+            match=_coerce_bool(item.get("match")),
+            confidence=_coerce_confidence(item.get("confidence")),
+            note=str(item.get("note", "")),
+        )
+
+    # Emit one verdict per requested rubric aspect, in rubric order, filling any
+    # the model omitted with a conservative non-match.
+    ordered = tuple(
+        by_aspect.get(
+            aspect,
+            RubricVerdict(
+                aspect=aspect,
+                match=False,
+                confidence=0.0,
+                note="No verdict returned for this aspect.",
+            ),
+        )
+        for aspect in rubric
+    )
+
+    return ImageComparison(
+        match=_coerce_bool(data.get("match")),
+        confidence=_coerce_confidence(data.get("confidence")),
+        explanation=str(data.get("explanation", "")),
+        aspects=ordered,
+        model=model,
+    )
+
+
+def _loads_lenient(text: str) -> Any:
+    """Parse JSON, tolerating a surrounding ```/```json code fence or prose.
+
+    Tries a direct parse, then a fence strip, then the first ``{...}`` span.
+    Raises ``ValueError`` if nothing parses.
+    """
+    stripped = text.strip()
+    candidates = [stripped]
+    if stripped.startswith("```"):
+        lines = stripped.split("\n")
+        inner = "\n".join(lines[1:-1])
+        if inner.startswith("json"):
+            inner = inner[4:].strip()
+        candidates.append(inner)
+    start, end = stripped.find("{"), stripped.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        candidates.append(stripped[start : end + 1])
+
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except (json.JSONDecodeError, TypeError):
+            continue
+    raise ValueError(
+        f"Could not parse a JSON verdict from the model reply: {text[:120]!r}"
+    )
 
 
 def _to_image_url(image: "Union[str, Path, bytes, Any]") -> str:

--- a/tests/test_compare_images.py
+++ b/tests/test_compare_images.py
@@ -1,0 +1,260 @@
+"""Tests for aix.vision.compare_images (offline — LiteLLM is mocked, $0 spend).
+
+These mirror test_vision.py's approach: patch the ``_litellm_completion`` object
+on the ``aix.vision`` submodule and feed it a canned response, so no real API
+call (and no token spend) ever happens.
+"""
+
+import json
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aix.vision import (
+    compare_images,
+    ImageComparison,
+    RubricVerdict,
+    DFLT_COMPARE_RUBRIC,
+    DFLT_FILM_RUBRIC,
+)
+
+# `aix.vision` may resolve to the exported function name on some builds; patch
+# the submodule object directly (same robustness trick as test_vision.py).
+import aix.vision  # noqa: F401
+
+_aix_vision = sys.modules["aix.vision"]
+
+
+def _verdict_json(rubric=DFLT_COMPARE_RUBRIC, *, match=True, confidence=0.9):
+    """A well-formed JSON verdict covering every aspect in ``rubric``."""
+    return json.dumps(
+        {
+            "match": match,
+            "confidence": confidence,
+            "explanation": "Candidate matches the reference well.",
+            "aspects": [
+                {
+                    "aspect": aspect,
+                    "match": match,
+                    "confidence": confidence,
+                    "note": f"{aspect} looks consistent.",
+                }
+                for aspect in rubric
+            ],
+        }
+    )
+
+
+def _mock_response(text):
+    response = Mock()
+    response.choices = [Mock()]
+    response.choices[0].message = Mock()
+    response.choices[0].message.content = text
+    return response
+
+
+class TestStructuredResult:
+    """The verdict parses into the documented typed shape."""
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_default_rubric_shape(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+
+        result = compare_images(
+            "https://x/candidate.jpg", "https://x/ref.jpg", model="gpt-4o", api_key="sk-test"
+        )
+
+        assert isinstance(result, ImageComparison)
+        assert result.match is True
+        assert 0.0 <= result.confidence <= 1.0
+        assert result.explanation
+        assert result.model == "gpt-4o"
+        # One verdict per default rubric aspect, in order, mapping-like access.
+        assert len(result) == len(DFLT_COMPARE_RUBRIC)
+        assert tuple(result) == DFLT_COMPARE_RUBRIC
+        for aspect in DFLT_COMPARE_RUBRIC:
+            assert aspect in result
+            verdict = result[aspect]
+            assert isinstance(verdict, RubricVerdict)
+            assert verdict.aspect == aspect
+            assert isinstance(verdict.match, bool)
+            assert 0.0 <= verdict.confidence <= 1.0
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_mapping_helpers(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+        result = compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+        # .get with default, __contains__ negative
+        assert result.get("identity") is result["identity"]
+        assert result.get("nonexistent") is None
+        assert "nonexistent" not in result
+
+
+class TestRubricHonored:
+    """Caller-supplied rubric drives the aspects."""
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_custom_rubric_aspects_appear(self, mock_completion):
+        custom = ("face", "architecture", "props", "lighting")
+        mock_completion.return_value = _mock_response(_verdict_json(custom))
+
+        result = compare_images(
+            "https://x/c.jpg", "https://x/r.jpg", rubric=custom, model="gpt-4o", api_key="sk-test"
+        )
+
+        assert tuple(result) == custom
+        # The rubric aspects must be threaded into the prompt text.
+        prompt = mock_completion.call_args[1]["messages"][0]["content"][0]["text"]
+        for aspect in custom:
+            assert aspect in prompt
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_film_rubric(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json(DFLT_FILM_RUBRIC))
+        result = compare_images(
+            "https://x/c.jpg", "https://x/r.jpg", rubric=DFLT_FILM_RUBRIC, model="gpt-4o", api_key="sk-test"
+        )
+        assert "face_identity" in result
+        assert result["skin_realism"].aspect == "skin_realism"
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_missing_aspect_filled_conservatively(self, mock_completion):
+        # Model omits one aspect; result must still cover the full rubric.
+        partial = json.dumps(
+            {
+                "match": False,
+                "confidence": 0.4,
+                "explanation": "Mixed.",
+                "aspects": [
+                    {"aspect": "identity", "match": True, "confidence": 0.9, "note": "ok"}
+                ],
+            }
+        )
+        mock_completion.return_value = _mock_response(partial)
+
+        result = compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+
+        assert len(result) == len(DFLT_COMPARE_RUBRIC)
+        assert result["identity"].match is True
+        # An omitted aspect (e.g. "props") is present as a conservative non-match.
+        assert result["props"].match is False
+        assert result["props"].confidence == 0.0
+
+
+class TestReferenceInputs:
+    """Reference may be a single image or a locked set (sequence)."""
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_single_reference_one_image_block(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+
+        compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+
+        content = mock_completion.call_args[1]["messages"][0]["content"]
+        # text + candidate + 1 reference = 3 blocks
+        image_blocks = [b for b in content if b.get("type") == "image_url"]
+        assert len(image_blocks) == 2
+        # candidate is first image block
+        assert image_blocks[0]["image_url"]["url"] == "https://x/c.jpg"
+        assert image_blocks[1]["image_url"]["url"] == "https://x/r.jpg"
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_reference_sequence_builds_multiple_blocks(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+
+        refs = ["https://x/r1.jpg", "https://x/r2.jpg", "https://x/r3.jpg"]
+        compare_images("https://x/c.jpg", refs, model="gpt-4o", api_key="sk-test")
+
+        content = mock_completion.call_args[1]["messages"][0]["content"]
+        image_blocks = [b for b in content if b.get("type") == "image_url"]
+        # candidate + 3 references = 4 image blocks
+        assert len(image_blocks) == 4
+        urls = [b["image_url"]["url"] for b in image_blocks]
+        assert urls == ["https://x/c.jpg", *refs]
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_data_uri_reference_treated_as_atomic(self, mock_completion):
+        # A data: URI string must NOT be iterated character-wise.
+        mock_completion.return_value = _mock_response(_verdict_json())
+        uri = "data:image/png;base64,AAAA"
+        compare_images("https://x/c.jpg", uri, model="gpt-4o", api_key="sk-test")
+        content = mock_completion.call_args[1]["messages"][0]["content"]
+        image_blocks = [b for b in content if b.get("type") == "image_url"]
+        assert len(image_blocks) == 2
+        assert image_blocks[1]["image_url"]["url"] == uri
+
+
+class TestThreading:
+    """Model params are threaded into the LiteLLM call."""
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_temperature_defaults_to_zero(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+        compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+        assert mock_completion.call_args[1]["temperature"] == 0.0
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_max_tokens_and_detail_threaded(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+        compare_images(
+            "https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test", max_tokens=256, detail="high"
+        )
+        kwargs = mock_completion.call_args[1]
+        assert kwargs["max_tokens"] == 256
+        blocks = [b for b in kwargs["messages"][0]["content"] if b.get("type") == "image_url"]
+        assert all(b["image_url"]["detail"] == "high" for b in blocks)
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_extra_kwargs_forwarded(self, mock_completion):
+        mock_completion.return_value = _mock_response(_verdict_json())
+        compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test", top_p=0.3)
+        assert mock_completion.call_args[1]["top_p"] == 0.3
+
+
+class TestLenientParsing:
+    """The JSON contract tolerates code fences and surrounding prose."""
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_code_fence_stripped(self, mock_completion):
+        fenced = "```json\n" + _verdict_json() + "\n```"
+        mock_completion.return_value = _mock_response(fenced)
+        result = compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+        assert result.match is True
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_prose_wrapped_json_recovered(self, mock_completion):
+        wrapped = "Here is my verdict:\n" + _verdict_json() + "\nHope that helps!"
+        mock_completion.return_value = _mock_response(wrapped)
+        result = compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+        assert len(result) == len(DFLT_COMPARE_RUBRIC)
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_unparseable_reply_raises(self, mock_completion):
+        mock_completion.return_value = _mock_response("not json at all, sorry")
+        with pytest.raises(ValueError, match="parse a JSON verdict"):
+            compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+
+
+class TestErrors:
+    """Sensible errors on empty / invalid input — raised before any API call."""
+
+    def test_empty_rubric_raises(self):
+        with pytest.raises(ValueError, match="at least one aspect"):
+            compare_images("https://x/c.jpg", "https://x/r.jpg", rubric=(), model="gpt-4o", api_key="sk-test")
+
+    def test_empty_reference_sequence_raises(self):
+        with pytest.raises(ValueError, match="at least one image"):
+            compare_images("https://x/c.jpg", [], model="gpt-4o", api_key="sk-test")
+
+    def test_missing_litellm_raises_importerror(self):
+        with patch.object(_aix_vision, "_litellm_completion", None):
+            with pytest.raises(ImportError, match="LiteLLM is required"):
+                compare_images("https://x/c.jpg", "https://x/r.jpg", model="gpt-4o", api_key="sk-test")
+
+    @patch.object(_aix_vision, "_litellm_completion")
+    def test_errors_raised_before_api_call(self, mock_completion):
+        # Empty rubric must short-circuit BEFORE the (paid) completion call.
+        with pytest.raises(ValueError):
+            compare_images("https://x/c.jpg", "https://x/r.jpg", rubric=[], model="gpt-4o", api_key="sk-test")
+        mock_completion.assert_not_called()


### PR DESCRIPTION
Adds `aix.compare_images(candidate, reference, *, rubric=..., model=...) -> ImageComparison` over the existing `to_image_content` + multimodal completion path: an explainable per-aspect verdict (overall match + per-rubric `{aspect, match, confidence, note}`). This is the "explain the drift" half of reelee's reference supervisor — the free numeric identity-cosine gate lives in lookbook. Part of epic **thorwhalen/reelee-web#151**.

Default rubric `(identity, costume, setting, lighting, props)`; `DFLT_FILM_RUBRIC` covers Noel's face/costume/setting/lighting/props/skin checklist. Result is mapping-like (`cmp["identity"].match`). Tests mock the LLM (no spend): **18 new tests, +18 over baseline, zero regressions.**

⚠️ The implementing pass found a **pre-existing** bug (NOT in this PR, present on master): `aix.credentials.resolve_api_key("provider/model")` returns `None` (only a bare `provider` resolves), which silently fails ~42 pre-existing suite tests. Recommend a separate fix — it would bite any consumer using a `provider/model` id.

Closes #36

https://claude.ai/code/session_01VpuLiVm21Wf3F3NUSveVwV